### PR TITLE
Only show meta details on news and blog pages

### DIFF
--- a/app/modules/news/tests/fixtures.py
+++ b/app/modules/news/tests/fixtures.py
@@ -47,7 +47,7 @@ def news_index_page(home_page) -> NewsIndexPage:
 
 @pytest.fixture(scope="function")
 def news_page(news_index_page) -> News:
-    p = _create_news_index_page('Test News Item', news_index_page)
+    p = _create_news_page('Test News Item', news_index_page)
     return p
 
 @pytest.fixture(scope="function")

--- a/app/modules/news/tests/test_news.py
+++ b/app/modules/news/tests/test_news.py
@@ -15,3 +15,13 @@ def test_news_200(news_page):
     """
     rv = client.get(news_page.url)
     assert rv.status_code == 200
+
+def test_news_shows_tags(news_page):
+    """Test that we can see a news item's tags
+    """
+    news_page.tags.add("This is a tag")
+    news_page.save_revision().publish()
+
+    rv = client.get(news_page.url)
+
+    assert "This is a tag" in str(rv.content)

--- a/app/modules/news/tests/test_news_index_page.py
+++ b/app/modules/news/tests/test_news_index_page.py
@@ -55,3 +55,12 @@ def test_news_index_lists_news(news_index_page, news_items):
     for news_item in news_items:
         assert news_item.title in str(rv.content)
 
+def test_news_index_shows_tags(news_index_page, news_items):
+    """Test that we can see a blog post's tags
+    """
+    news_items[0].tags.add("This is a tag")
+    news_items[0].save_revision().publish()
+
+    rv = client.get(news_index_page.url)
+
+    assert "This is a tag" in str(rv.content)

--- a/app/templates/blog_posts/blog_post.html
+++ b/app/templates/blog_posts/blog_post.html
@@ -1,1 +1,1 @@
-{% include 'core/article_page.html' %}
+{% include 'core/article_page.html' with show_meta=True %}

--- a/app/templates/core/article_page.html
+++ b/app/templates/core/article_page.html
@@ -13,6 +13,9 @@
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-two-thirds">
         <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">{{ page.title }}</h1>
+        {% if show_meta %}
+          {% include '_partials/page_meta.html' %}
+        {% endif %}
       </div>
     </div>
     <div class="nhsuk-grid-row">

--- a/app/templates/news/news.html
+++ b/app/templates/news/news.html
@@ -1,1 +1,1 @@
-{% include 'core/article_page.html' %}
+{% include 'core/article_page.html' with show_meta=True %}


### PR DESCRIPTION
This restores the `page_meta` partial, with an added `show_meta` option, which is used by blog posts and news items, which ensures metadata is only shown for those pages.