### PR TITLE
Fix for the overly large gaps between news items on the news index page.

### DIFF
--- a/app/templates/blog_posts/blog_post_index_page.html
+++ b/app/templates/blog_posts/blog_post_index_page.html
@@ -1,1 +1,1 @@
-{% include 'core/index_page.html' with column_size="one-half" pages=children %}
+{% include 'core/index_page.html' with column_size="one-half" pages=children item_class="fixed-height" %}

--- a/app/templates/core/index_page.html
+++ b/app/templates/core/index_page.html
@@ -42,7 +42,7 @@
         {% endif %}
           {% for post in pages.object_list %}
             {% if post.id not in page.specific.featured_ids %}
-            <div class="nhsuk-grid-column-{{column_size}} nhsuk-u-margin-bottom-5 fixed-height">
+            <div class="nhsuk-grid-column-{{column_size}} nhsuk-u-margin-bottom-5 {{ item_class }}">
               <h3 class="nhsuk-heading-m">
                 <a href="{% pageurl post %}">{{post.title}}</a>
               </h3>

--- a/docker/web/Dockerfile-prod
+++ b/docker/web/Dockerfile-prod
@@ -45,6 +45,7 @@ RUN apk update && apk add --no-cache \
     zlib-dev \
     nodejs \
     nodejs-npm \
+    mailcap \
     zsh && \
     rm -f /tmp/* /etc/apk/cache/* /root/.cache
 


### PR DESCRIPTION
This ensures that we only set the fixed-height class on items on the blog index page, so the news index page doesn't get gaps larger than we want between items.