### PR TITLE
Only cache for fifteen minutes

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -316,7 +316,7 @@ CACHES = {
     'wagtail_cache': {
         "BACKEND": "wagtailcache.compat_backends.django_redis.RedisCache",
         'LOCATION': REDIS_HOST_PAGECACHE,
-        'TIMEOUT': 60 * 60 * 24 * 7,  # Seven days
+        'TIMEOUT': 60 * 15,  # Fifteen minutes
         'OPTIONS': {
             "PARSER_CLASS": "redis.connection.HiredisParser",
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',


### PR DESCRIPTION
We're currently holding onto pages in the Redis cache for a week, which is getting sent down the pipe to Cloudfront. This loosens up this restriction, only caching pages for 15 minutes. Ideally we should have some way of invalidating the Cloudfront cache when a page changes, but this is good enough to solve the issue publishers are currently having