### PR TITLE
Only fetch live pages when showing subnav

### DIFF
--- a/app/modules/core/models/abstract.py
+++ b/app/modules/core/models/abstract.py
@@ -123,7 +123,7 @@ class SubNavMixin(PageLinksMixin):
 
     @cached_property
     def _children(self):
-        children = self.get_children()
+        children = self.get_children().live()
         return [{'title': _.title, 'url': _.url} for _ in children]
 
     @cached_property


### PR DESCRIPTION
At the moment, the automatic sub navigation shows all pages, regardless of status (draft or live). This then means users who click on the subnav link get a 404, and may cause issues if something is in draft awaiting an embargo. This is a simple fix to stop this happening.