### PR TITLE
Add pagination to resource pages

### DIFF
--- a/app/assets/_dev/js/lib/ai_lab_resources.js
+++ b/app/assets/_dev/js/lib/ai_lab_resources.js
@@ -1,0 +1,33 @@
+"use strict";
+
+document.addEventListener("DOMContentLoaded", function () {
+  var loadResources = document.querySelector("#loadResources");
+  var resourceContainer = document.querySelector("#resources");
+
+  if (!loadResources || !resourceContainer) {
+    return;
+  }
+
+  loadResources.addEventListener("click", function (event) {
+    let url = this.getAttribute("href");
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url);
+    xhr.setRequestHeader('x-requested-with', 'XMLHttpRequest');
+    xhr.onload = function () {
+      if (xhr.status === 200) {
+        resourceContainer.innerHTML += xhr.responseText
+        var nextPage = xhr.getResponseHeader("next_page")
+        if (nextPage) {
+          url = url.replace(/page=(\d+)/, "page=" + nextPage);
+          loadResources.setAttribute("href", url);
+        } else {
+          loadResources.remove();
+        }
+      }
+    };
+    xhr.send();
+
+    event.preventDefault();
+  })
+})

--- a/app/config/assets.py
+++ b/app/config/assets.py
@@ -25,6 +25,7 @@ admin_css_files = ["_dev/scss/admin.scss"]
 
 core_js_files = [
     "_dev/js/lib/cookieconsent.min.js",
+    "_dev/js/lib/ai_lab_resources.js",
     "_dev/js/main.js",
 ]
 

--- a/app/modules/ai_lab/tests/test_ai_lab_resources.py
+++ b/app/modules/ai_lab/tests/test_ai_lab_resources.py
@@ -82,13 +82,27 @@ class TestAiLabResources:
 
         assert page.status_code == 200
 
-        for resource in (
-            understand_case_studies + develop_case_studies + adopt_case_studies
-        ):
+        resource_ids = [
+            _.id
+            for _ in (
+                understand_case_studies
+                + develop_case_studies
+                + adopt_case_studies
+                + understand_external_resources
+                + develop_external_resources
+            )
+        ]
+        resources = Page.objects.filter(id__in=resource_ids).order_by("title")
+
+        for resource in resources[0:9]:
             assert resource.title in str(page.content)
 
-        for resource in understand_external_resources + develop_external_resources:
-            assert resource.title in str(page.content)
+        page2 = client.get(resources_index_page.url + "?page=2")
+
+        assert page2.status_code == 200
+
+        for resource in resources[9:]:
+            assert resource.title in str(page2.content)
 
     def test_resource_index_page_shows_children(self):
         resource_index_page = AiLabUnderstandIndexPageFactory.create()

--- a/app/templates/ai_lab/_partials/resource.html
+++ b/app/templates/ai_lab/_partials/resource.html
@@ -1,0 +1,9 @@
+<div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
+  <div class="nhsuk-promo">
+    <div class="nhsuk-promo__content">
+      <a href="{{ resource.url }}">
+        <h2>{{ resource.title }}</h2>
+      </a>
+    </div>
+  </div>
+</div>

--- a/app/templates/ai_lab/_partials/resources.html
+++ b/app/templates/ai_lab/_partials/resources.html
@@ -1,0 +1,11 @@
+<div class="block-promo_group">
+  <div class="nhsuk-grid-row nhsuk-promo-group" id="resources">
+    {% for resource in resources %}
+    {% include 'ai_lab/_partials/resource.html' with resource=resource %}
+    {% endfor %}
+  </div>
+</div>
+
+{% if resources.has_next %}
+<a href="{{ page.url }}?page={{ resources.next_page_number }}" id="loadResources">Load More</a>
+{% endif %}

--- a/app/templates/ai_lab/ai_lab_category_index_page.html
+++ b/app/templates/ai_lab/ai_lab_category_index_page.html
@@ -18,21 +18,7 @@
       <div class="nhsuk-grid-column-full">
         {% include_block page.body %}
 
-        <div class="block-promo_group">
-          <div class="nhsuk-grid-row nhsuk-promo-group">
-            {% for resource in resources %}
-            <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
-              <div class="nhsuk-promo">
-                <div class="nhsuk-promo__content">
-                  <a href="{{ resource.url }}">
-                    <h2>{{ resource.title }}</h2>
-                  </a>
-                </div>
-              </div>
-            </div>
-            {% endfor %}
-          </div>
-        </div>
+        {% include 'ai_lab/_partials/resources.html' with resources=resources page=page %}
       </div>
     </div>
   </main>

--- a/app/templates/ai_lab/ai_lab_resource_index_page.html
+++ b/app/templates/ai_lab/ai_lab_resource_index_page.html
@@ -35,21 +35,7 @@
         </div>
         {% include_block page.body %}
 
-        <div class="block-promo_group">
-          <div class="nhsuk-grid-row nhsuk-promo-group">
-            {% for resource in resources %}
-            <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
-              <div class="nhsuk-promo">
-                <div class="nhsuk-promo__content">
-                  <a href="{{ resource.url }}">
-                    <h2>{{ resource.title }}</h2>
-                  </a>
-                </div>
-              </div>
-            </div>
-            {% endfor %}
-          </div>
-        </div>
+        {% include 'ai_lab/_partials/resources.html' with resources=resources page=page %}
       </div>
     </div>
   </main>

--- a/app/templates/ai_lab/ai_lab_resource_index_page.js.html
+++ b/app/templates/ai_lab/ai_lab_resource_index_page.js.html
@@ -1,0 +1,7 @@
+<div class="block-promo_group">
+  <div class="nhsuk-grid-row nhsuk-promo-group">
+    {% for resource in resources %}
+    {% include 'ai_lab/_partials/resource.html' with resource=resource %}
+    {% endfor %}
+  </div>
+</div>

--- a/app/templates/ai_lab/ai_lab_resource_index_page.js.html
+++ b/app/templates/ai_lab/ai_lab_resource_index_page.js.html
@@ -1,0 +1,3 @@
+{% for resource in resources %}
+{% include 'ai_lab/_partials/resource.html' with resource=resource %}
+{% endfor %}


### PR DESCRIPTION
This adds a simple pagination link to the resource pages. If JS is enabled, the response is injected into the page, as well as sending the next page as a HTTP header, so the next page link then requests the following page. If there are no pages remaining, the next page link is removed from the DOM:

![image](https://user-images.githubusercontent.com/109774/88543271-a46e4b80-d00f-11ea-8042-281fa11e5552.png)

![image](https://user-images.githubusercontent.com/109774/88543292-aa642c80-d00f-11ea-9f27-215102497157.png)


