### PR TITLE
Remove sorting by date on resources

### DIFF
--- a/app/modules/ai_lab/blocks.py
+++ b/app/modules/ai_lab/blocks.py
@@ -28,7 +28,7 @@ class ResourcesBlock(blocks.StructBlock):
 
         for type in resource_types:
             page = type.objects.all()[0]
-            child_resources = page.get_children().live().order_by("first_published_at")
+            child_resources = page.get_children().live()
             resources[page] = child_resources
 
         context.update({"resources": resources, "index_page": index_page})

--- a/app/modules/ai_lab/models/resource_listings.py
+++ b/app/modules/ai_lab/models/resource_listings.py
@@ -36,11 +36,7 @@ class AiLabFilterableResourceMixin(RoutablePageMixin):
     @route(r"^topic/([a-z\-0-9]+)/$")
     def filter_by_topic(self, request, topic=None, resource_type=None):
         context = self.get_context(request)
-        resources = (
-            self._get_resources(topic, resource_type)
-            .live()
-            .order_by("first_published_at")
-        )
+        resources = self._get_resources(topic, resource_type).live()
         template = self.get_template(request)
         topics = AiLabTopic.objects.all()
 

--- a/app/modules/ai_lab/tests/test_ai_lab_resources.py
+++ b/app/modules/ai_lab/tests/test_ai_lab_resources.py
@@ -94,14 +94,14 @@ class TestAiLabResources:
         ]
         resources = Page.objects.filter(id__in=resource_ids).order_by("title")
 
-        for resource in resources[0:9]:
+        for resource in resources_index_page.get_children()[0:9]:
             assert resource.title in str(page.content)
 
         page2 = client.get(resources_index_page.url + "?page=2")
 
         assert page2.status_code == 200
 
-        for resource in resources[9:]:
+        for resource in resources_index_page.get_children()[9:]:
             assert resource.title in str(page2.content)
 
     def test_resource_index_page_shows_children(self):


### PR DESCRIPTION
This allows `get_children` to respect the order set by dragging and dropping in the CMS