### PR TITLE
Remove `LOGIN_URL` override from settings

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -267,7 +267,6 @@ AUTH_USER_MODEL = "users.User"
 WAGTAILIMAGES_IMAGE_MODEL = "images.NHSXImage"
 WAGTAILDOCS_DOCUMENT_MODEL = "documents.NHSXDocument"
 WAGTAIL_SITE_NAME = "NHSX"
-LOGIN_URL = "auth:login"
 
 DEFAULT_AUTHOR_AVATAR = "avatar.png"
 


### PR DESCRIPTION
We're having an issue when carrying out password resets, where the error `NoReverseMatch: 'auth' is not a registered namespace` gets raised. I tracked it down to this line in Django:

https://github.com/django/django/blob/4f61810751751b8c5070ce038ea57e949650e9e3/django/contrib/auth/views.py#L326

I then noticed that we were overriding `LOGIN_URL` to go to `auth:login`, which I assume is some config copied over from another project. I removed this line and password resets are now not erroring, and we can still log in and out without issue.