### PR TITLE
Only show related case studies if they are live

### DIFF
--- a/app/modules/ai_lab/models/resources.py
+++ b/app/modules/ai_lab/models/resources.py
@@ -86,7 +86,8 @@ class AiLabResourceMixin(models.Model):
         from modules.ai_lab.models import AiLabResourceIndexPage
 
         root_page = AiLabResourceIndexPage.objects.all()[0]
-        child_resources = list(root_page._get_resources())
+
+        child_resources = list(root_page._get_resources().live())
 
         if self in child_resources:
             child_resources.remove(self)

--- a/app/modules/ai_lab/tests/test_ai_lab_resource.py
+++ b/app/modules/ai_lab/tests/test_ai_lab_resource.py
@@ -75,7 +75,7 @@ class TestAiLabResource:
             assert case_study.title in str(page.content)
             assert case_study.title in str(page.content)
 
-    def test_case_study_shows_resources_with_the_same_tag(self):
+    def test_case_study_shows_live_resources_with_the_same_tag(self):
         topic1 = AiLabTopicFactory.create()
         topic2 = AiLabTopicFactory.create()
         category_page = AiLabUnderstandIndexPageFactory.create()
@@ -86,20 +86,20 @@ class TestAiLabResource:
 
         AiLabCaseStudyFactory.create_batch(4, parent=category_page)
 
-        featured_case_study_1 = AiLabCaseStudyFactory.create(
-            parent=category_page, topics=[topic1]
+        live_featured_case_study = AiLabCaseStudyFactory.create(
+            parent=category_page, topics=[topic1], live=True
         )
-        featured_case_study_2 = AiLabCaseStudyFactory.create(
-            parent=category_page, topics=[topic2]
+        draft_featured_case_study = AiLabCaseStudyFactory.create(
+            parent=category_page, topics=[topic2], live=False
         )
 
         page = client.get(case_study.url)
 
         assert page.status_code == 200
 
-        assert featured_case_study_1.title in str(page.content)
-        assert featured_case_study_2.title in str(page.content)
-
+        assert live_featured_case_study.title in str(page.content)
+        assert draft_featured_case_study.title not in str(page.content)
+        
     def test_case_study_shows_featured_resources(self):
         topic = AiLabTopicFactory.create()
         category_page = AiLabUnderstandIndexPageFactory.create()


### PR DESCRIPTION
It was possible to have a draft `live=False` Wagtail document which would appear at the bottom of a related case study in the further reading section.

We tag on `.live()` to filter out all resources that aren't yet published.

I've baked in the new assertion into an existing test given that setting related topics is also required to create the failing scenario. Happy to split that out into an individual test if that would be clearer?