### PR TITLE
Add topics links to guidance pages

### DIFF
--- a/app/modules/ig_guidance/models.py
+++ b/app/modules/ig_guidance/models.py
@@ -146,8 +146,14 @@ class GuidanceListingPage(RoutablePageMixin, BasePage):
                     ids.append(obj.id)
             guidance = Page.objects.filter(id__in=(ids)).specific()
 
+        tags = IGGuidanceTag.objects.all()
+
         context.update(
-            {"guidance": guidance,}
+            {
+                "guidance": guidance,
+                "tags": tags,
+                "tag": tag,
+            }
         )
 
         return TemplateResponse(request, template, context)

--- a/app/modules/ig_guidance/templatetags/guidance_tags.py
+++ b/app/modules/ig_guidance/templatetags/guidance_tags.py
@@ -19,3 +19,10 @@ def guidance_target(guidance):
 @register.filter
 def guidance_tag_url(page, tag):
     return page.url + page.reverse_subpage("filter_by_tag", args=(tag.slug,))
+
+@register.filter
+def guidance_tag(tag, current_tag):
+    if tag.slug == current_tag:
+        return "tag current"
+    else:
+        return "tag"

--- a/app/templates/_partials/topics.html
+++ b/app/templates/_partials/topics.html
@@ -1,0 +1,16 @@
+{% load guidance_tags %}
+
+<div class="topics nhsai-topics">
+  <span class="tag">
+    <a href="{{ page.url }}">
+      View all
+    </a>
+  </span>
+  {% for topic in topics %}
+  <span class="{{ topic|guidance_tag:current_topic }}">
+    <a href="{{ page|guidance_tag_url:topic }}">
+      {{ topic.name }}
+    </a>
+  </span>
+  {% endfor %}
+</div>

--- a/app/templates/ig_guidance/guidance_listing_page.html
+++ b/app/templates/ig_guidance/guidance_listing_page.html
@@ -14,6 +14,7 @@
       <div class="nhsuk-grid-column-full nhsuk-u-margin-bottom-5">
         <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">{{ page.title }}</h1>
         {{ page.body }}
+        {% include '_partials/topics.html' with page=page topics=tags current_topic=tag %}
         {% regroup guidance|dictsort:"topic.name" by topic.name as item_list %}
         {% for items in item_list %}
         <h2>{{ items.grouper }}</h2>


### PR DESCRIPTION
Mirroring the behaviour of AI Lab, add topic links to the top of guidance pages.