### PR TITLE
Fix social media preview URLs

### DIFF
--- a/app/modules/core/templatetags/social_tags.py
+++ b/app/modules/core/templatetags/social_tags.py
@@ -38,3 +38,12 @@ def twitter_card_image(page, site):
         return page.twitter_card_image
     else:
         return MetaTagSettings.for_site(site).image
+
+
+@register.filter(name="social_tag_url")
+def social_tag_url(page, image):
+    if image.url.startswith("http"):
+        return image.url
+    else:
+        return page.get_site().root_url + image.url
+

--- a/app/templates/_partials/head_meta.html
+++ b/app/templates/_partials/head_meta.html
@@ -2,8 +2,11 @@
 
 <meta charset="utf-8" />
 <meta http-equiv="x-ua-compatible" content="ie=edge">
-<title>{% block title_prefix %}{{ TITLE_PREFIX }}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %} - NHSX{% endblock %}</title>
-<meta name="description" content="{% if page.search_description %}{{ page.search_description }}{% else %}{{ page|fb_og_description:request.site }}{% endif %}" />
+<title>
+    {% block title_prefix %}{{ TITLE_PREFIX }}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}
+    - NHSX{% endblock %}</title>
+<meta name="description"
+    content="{% if page.search_description %}{{ page.search_description }}{% else %}{{ page|fb_og_description:request.site }}{% endif %}" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 {% if page.canonical_rel %}
@@ -21,19 +24,28 @@
 
 {% if not request.is_preview %}
 <meta name="twitter:card" content="summary" />
-{% if settings.core.SocialMediaSettings.twitter %}<meta name="twitter:site" content="@{{ settings.core.SocialMediaSettings.twitter }}" />{% endif %}
+{% if settings.core.SocialMediaSettings.twitter %}
+<meta name="twitter:site" content="@{{ settings.core.SocialMediaSettings.twitter }}" />{% endif %}
 <meta name="twitter:title" content="{{ page.title }}" />
 <meta name="twitter:description" content="{{ page|twitter_card_description:request.site }}">
-{% if page|twitter_card_image:request.site %}<meta property="og:image" content="{% image page|twitter_card_image:request.site fill-1000x1000 as twitter_card_image %}{{ page.get_site.root_url }}{{ twitter_card_image.url }}" />{% endif %}
-{% if settings.core.SocialMediaSettings.facebook_app_id %}<meta property="fb:app_id" content="{{ settings.SocialMediaSettings.facebook_app_id }}" />{% endif %}
+{% if page|twitter_card_image:request.site %}
+{% image page|twitter_card_image:request.site fill-1000x1000 as twitter_card_image %}
+<meta property="og:image" content="{{ page|social_tag_url:twitter_card_image }}" />
+{% endif %}
+{% if settings.core.SocialMediaSettings.facebook_app_id %}
+<meta property="fb:app_id" content="{{ settings.SocialMediaSettings.facebook_app_id }}" />{% endif %}
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ page.full_url }}" />
 <meta property="og:title" content="{{ page.title }}" />
-{% if page|fb_image:request.site %}<meta property="og:image" content="{% image page|fb_image:request.site fill-1200x630 as fb_image %}{{ page.get_site.root_url }}{{ fb_image.url }}" />{% endif %}
+{% if page|fb_image:request.site %}
+{% image page|fb_image:request.site fill-1200x630 as fb_image %}
+<meta property="og:image" content="{{ page|social_tag_url:fb_image }}" />
+{% endif %}
 <meta property="og:description" content="{{ page|fb_og_description:request.site }}" />
-{% if settings.core.SocialMediaSettings.site_name %}<meta property="og:site_name" content="{{ settings.core.SocialMediaSettings.site_name }}" />{% endif %}
+{% if settings.core.SocialMediaSettings.site_name %}
+<meta property="og:site_name" content="{{ settings.core.SocialMediaSettings.site_name }}" />{% endif %}
 {% endif %}
 {% block extra_css %}{% endblock %}
 {% if server_env == 'staging' %}
-    <meta name="robots" content="noindex">
+<meta name="robots" content="noindex">
 {% endif %}


### PR DESCRIPTION
A call to `.url` on an image in production behaves differently to development, and returns a full URL. This results in the root url being doubled up in production.

This adds a new tag to check if the url begins with `http`. If it does we just return the url, if not, we prepend the image url with the site's root url.

This means the images work the same in prod and dev, and we guard against any infrastructure changes that might happen to alter the behaviour in prod.