### PR TITLE
Make call to sed compatible with both GNU and BSD versions

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -3,7 +3,8 @@ set -e -u -o pipefail
 
 SECRET=$(openssl rand -base64 32 | sed -e 's/[\/&]/\\&/g')
 cp docker-compose.env.example docker-compose.env
-sed -i '' -e "s/SECRET_KEY_GOES_HERE/$SECRET/g" docker-compose.env
+sed -i.bak -e "s/SECRET_KEY_GOES_HERE/$SECRET/g" docker-compose.env
+rm docker-compose.env.bak
 
 docker-compose build
 script/manpy migrate


### PR DESCRIPTION
macOS uses BSD sed. The `-i` argument has inconsistent behaviour between
GNU and BSD versions.

GNU sed man page from Ubuntu 20.10:

```
       -i[SUFFIX], --in-place[=SUFFIX]
```

BSD sed man page from macOS 10.15:

```
     -i extension
```

"No extension" would be indicated with `-i=` in GNU sed and `-i ''` in
BSD sed. The workaround here creates a .bak file and then deletes it.