### PR TITLE
Run Black in CI

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,7 @@ services:
       - /bin/bash
       - -c
       - |
+        set -e
         black --check .
         python manage.py assets clean
         python manage.py assets build


### PR DESCRIPTION
The CI currently ignores if Black fails, which means some incorrectly formatted code has sneaked in. This should fix it.