### PR TITLE
Format time to match NHS style guide

### DIFF
--- a/app/modules/core/templatetags/time_tags.py
+++ b/app/modules/core/templatetags/time_tags.py
@@ -1,0 +1,14 @@
+from django import template
+from django.template.defaultfilters import time
+
+register = template.Library()
+
+
+@register.filter
+def format_time(time_obj):
+    if time_obj.hour == 12 and time_obj.minute == 0:
+        return "midday"
+    elif time_obj.hour == 0 and time_obj.minute == 0:
+        return "midnight"
+    else:
+        return time(time_obj, "g.iA").lower()

--- a/app/modules/core/tests/test_time_tags.py
+++ b/app/modules/core/tests/test_time_tags.py
@@ -1,0 +1,8 @@
+from modules.core.templatetags import time_tags
+import datetime
+
+
+def test_format_time():
+    assert time_tags.format_time(datetime.time(12, 0)) == "midday"
+    assert time_tags.format_time(datetime.time(0, 0)) == "midnight"
+    assert time_tags.format_time(datetime.time(15, 30)) == "3.30pm"

--- a/app/templates/meeting_minutes/meeting_minutes.html
+++ b/app/templates/meeting_minutes/meeting_minutes.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags %}
+{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags time_tags %}
 
 {% block body_class %}template-article{% endblock %}
 
@@ -17,7 +17,7 @@
             <span class="nhsuk-caption-l">{{ page.get_parent.title }}</span>
             {{ page.title }}
           </h1>
-          <p class="nhsuk-body-l">{{ page.start_time }} - {{ page.end_time }}</p>
+          <p class="nhsuk-body-l">{{ page.start_time|format_time }} - {{ page.end_time|format_time }}</p>
           <p class="nhsuk-body-l">{{ page.venue }}</p>
 
           <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible">


### PR DESCRIPTION
The [NHS Style Guide](https://service-manual.nhs.uk/content/numbers-measurements-dates-time) mandates that times are written with a decimal point seperating the hour and minute, and "am" and "pm" in lower case, as well as "midday" and "midnight" being specified for 12pm and 12am respecively. This is different from the Django default, so I've added a template tag to get around this, together with some tests.