### PR TITLE
Add asset commands to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ hosts` and add the following to make the site available at
 The following script runs the tests:
 
 ```bash
-script/tests
+script/test
 ```
 
 For more on the approach to testing, see [docs/testing.md](https://github.com/nhsx/nhsx-website/blob/dev/docs/testing.md)

--- a/script/setup
+++ b/script/setup
@@ -16,3 +16,7 @@ docker-compose run \
     --noinput \
     --email admin@example.com
 
+echo "***** cleaning, building and collecting the assets *****"
+script/manpy assets clean
+script/manpy assets build
+script/manpy collectstatic --no-input -i node_modules


### PR DESCRIPTION
As a complete Wagtail noob on support I needed to run the NHSX site
locally and found all the test failed due to a missing Apple touch icon.

Speaking with a developer, running these commands resolved the issue, so
I felt it was worth adding them to the readme for other folks.