### PR TITLE
Fix/remove fixed height on post containers

### DIFF
--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -1,45 +1,55 @@
 // make images show at the width of the column
 
 figure.nhsuk-image {
-    width: 100%;
+  width: 100%;
 }
 
-div.fixed-height{
-    height: 400px;
+div.fixed-height {
+  height: 400px;
 }
 
-
-img.richtext-image, img.full-width{
-    width: 100%;
-    height: auto;
+img.richtext-image,
+img.full-width {
+  width: 100%;
+  height: auto;
 }
 div.rich-text:last-child {
   p {
-    margin-bottom:nhsuk-spacing(4);
+    margin-bottom: nhsuk-spacing(4);
   }
 }
 
 //responsive embed videos
 
-.responsive-embed, .responsive-object {
-    height: 100%;
-    position: relative;
-    padding-bottom: 56.25%;
-    height: 0;
-    margin: 0 auto;
-    max-height: 100vh;
+.responsive-embed,
+.responsive-object {
+  height: 100%;
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  margin: 0 auto;
+  max-height: 100vh;
+  width: 100%;
+  video,
+  iframe,
+  img,
+  a {
+    position: absolute;
+    min-width: 100%;
+    min-height: 100%;
     width: 100%;
-    video, iframe, img, a {
-      position: absolute;
-      min-width: 100%;
-      min-height: 100%;
-      width: 100%;
-      height: auto;
-      max-height: 100vh;
-      overflow: hidden;
-    }
-    video, iframe {
-      z-index: 1;
-    }
+    height: auto;
+    max-height: 100vh;
+    overflow: hidden;
+  }
+  video,
+  iframe {
+    z-index: 1;
+  }
 }
 
+//basic flexbox layout
+
+.dxw-card-group {
+  @include flex();
+}

--- a/app/templates/blog_posts/blog_post_index_page.html
+++ b/app/templates/blog_posts/blog_post_index_page.html
@@ -1,1 +1,1 @@
-{% include 'core/index_page.html' with column_size="one-half" pages=children item_class="fixed-height" %}
+{% include 'core/index_page.html' with column_size="one-half" pages=children item_class="" %}

--- a/app/templates/core/index_page.html
+++ b/app/templates/core/index_page.html
@@ -38,7 +38,7 @@
         {% if hero_image or hero_text %}
         <div class="nhsuk-grid-row nhsuk-u-margin-top-5">
           {%else %}
-         <div class="nhsuk-grid-row">
+         <div class="nhsuk-grid-row dxw-card-group">
         {% endif %}
           {% for post in pages.object_list %}
             {% if post.id not in page.specific.featured_ids %}


### PR DESCRIPTION
The fix addressees

> From the accessibility report: at 400% zoom and in mobile view, some of the blogs with longer headings are overlapping the text of the previous blog making the text difficult to read

- Removed fixed height.
- Included Flexbox layout as a progressive enhancement which will fall back to floated layout, only affecting slight layout difference for below IE10, but remaining accessible for all browsers as higher priority.

![Overlapping text on blog](https://user-images.githubusercontent.com/2226904/104433878-7c08e800-5582-11eb-880c-337d668028f0.png)
