### PR TITLE
Fix/long anchor link text with wrap

### DIFF
--- a/app/assets/_dev/scss/base/_article_page.scss
+++ b/app/assets/_dev/scss/base/_article_page.scss
@@ -1,18 +1,17 @@
-
 //article page
 .template-article {
   .topics {
-    margin-bottom:  nhsuk-spacing(3);
+    margin-bottom: nhsuk-spacing(3);
   }
 }
 .block-block_quote {
-  @include nhsuk-responsive-margin(5, 'left');
+  @include nhsuk-responsive-margin(5, "left");
   &:before {
     content: "\201C";
     font-size: 30px;
     float: left;
     clear: both;
-    margin-right:nhsuk-spacing(3);
+    margin-right: nhsuk-spacing(3);
     line-height: 38px;
   }
   blockquote {
@@ -22,7 +21,6 @@
     }
   }
 }
-
 
 //Rich text first paragraph selector
 .block-rich_text:first-child {
@@ -37,10 +35,16 @@
   }
 }
 
+//Rich text handle long anchor links overflow
+.rich-text {
+  a {
+    @include word-wrap;
+  }
+}
 
 //sidebar
 .nhsuk-contents-list {
   h2 {
-    margin-bottom:13px;
+    margin-bottom: 13px;
   }
 }

--- a/app/assets/_dev/scss/helpers/_mixins.scss
+++ b/app/assets/_dev/scss/helpers/_mixins.scss
@@ -63,4 +63,16 @@
   opacity: $trans;
 }
 
+@mixin word-wrap() {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
 $is-ie: false !default;


### PR DESCRIPTION
The fix addresses

> At 400% zoom, several of the links and email addresses within the accordion sections are cut off at the end. In mobile view the page shifts to the left to allow these links and email addresses to fit on the page which affects the page's ability to reflow properly.

- Implemented `word-wrap` styles on all links within content area to break onto separate lines.

![screenshot showing overflow of link](https://user-images.githubusercontent.com/2226904/104436216-3b5e9e00-5585-11eb-96f7-04eb92d21cfe.png)

![screenshot showing fixed overflow of link](https://user-images.githubusercontent.com/2226904/104436213-3ac60780-5585-11eb-9d6a-3c9329b38ae2.png)

