### PR TITLE
Embed accessibility

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -270,7 +270,24 @@ WAGTAIL_SITE_NAME = "NHSX"
 DEFAULT_AUTHOR_AVATAR = "avatar.png"
 
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+    "default": {
+        "WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea",
+        "OPTIONS": {
+            "features": [
+                "h2",
+                "h3",
+                "h4",
+                "ol",
+                "ul",
+                "hr",
+                "bold",
+                "italic",
+                "link",
+                "document-link",
+                "image",
+            ]
+        },
+    },
     "alt": {"WIDGET": "wagtail.admin.rich_text.HalloRichTextArea"},
 }
 


### PR DESCRIPTION
This is a two-fold PR, firstly it fixes the issue with captioned embeds not generating acessible HTML by creating a shared class that is used by both embed blocks to append a `title` attribute to the generated iframe. It also removes the ability for users to use the Rich Text editor to embed media, as this creates inaccessible HTML.