### PR TITLE
Catch when a page number is non-numeric

### DIFF
--- a/app/modules/core/models/abstract.py
+++ b/app/modules/core/models/abstract.py
@@ -513,7 +513,10 @@ class BaseIndexPage(BasePage, InlineHeroMixin):
             tags = request_tags.split(",")
 
         if request.GET.get("page", None):
-            page = int(request.GET.get("page", 1))
+            try:
+                page = int(request.GET.get("page", 1))
+            except ValueError:
+                page = 1
 
         children = self._paginator(request, page, tags)
 


### PR DESCRIPTION
If a non-numeric variable is added for `page` on the listings pages, this causes the app to choke. The proper solution is to use Django's built-in pagination functionality, and Wagtail routing, but this solves the initial problem