### PR TITLE
Only show live siblings in the sidebar

### DIFF
--- a/app/modules/core/models/abstract.py
+++ b/app/modules/core/models/abstract.py
@@ -151,7 +151,7 @@ class SidebarMixin(PageLinksMixin):
 
     @cached_property
     def _siblings(self):
-        sibs = self.get_siblings()
+        sibs = self.get_siblings().live()
         return [{"title": _.title, "url": _.url} for _ in sibs]
 
     @cached_property


### PR DESCRIPTION
When we set the sidebar to automatically populate, we only want live pages to show, otherwise we end up seeing draft pages listed, which then link to a 404.