### PR TITLE
add styles to apply max-width to rich text images

### DIFF
--- a/app/assets/_dev/scss/base/_article_page.scss
+++ b/app/assets/_dev/scss/base/_article_page.scss
@@ -4,22 +4,28 @@
     margin-bottom: nhsuk-spacing(3);
   }
 }
+
 .block-block_quote {
   @include nhsuk-responsive-margin(5, "left");
   display: flex;
-  &:before, &:after {
+
+  &:before,
+  &:after {
     font-size: 30px;
     content: "\201C";
     line-height: 38px;
     margin-top: 10px;
   }
+
   &:before {
     text-align: right;
   }
+
   &:after {
     text-align: left;
     margin-right: nhsuk-spacing(3);
   }
+
   // &:before {
   //   content: "\201C";
   //   font-size: 30px;
@@ -38,6 +44,7 @@
   // }
   blockquote {
     margin-left: nhsuk-spacing(5);
+
     &:last-child {
       margin-bottom: nhsuk-spacing(4);
     }
@@ -48,10 +55,12 @@
 .block-rich_text:first-child {
   p:first-child {
     font-size: 19px;
+
     @media (min-width: 40.0625em) {
       font-size: 24px;
     }
   }
+
   div.rich-text :last-child {
     margin-bottom: 24px;
   }

--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -13,6 +13,20 @@ img.full-width {
   width: 100%;
   height: auto;
 }
+
+//Some max-width for images in rich-text
+//Ideally this should be done in the wagtail-nhsuk-frontend package
+//But not possible at this time
+
+img.richtext-image {
+
+  // full width already catered for above
+  &.left,
+  &.right {
+    max-width: 280px;
+  }
+}
+
 div.rich-text:last-child {
   p {
     margin-bottom: nhsuk-spacing(4);
@@ -30,6 +44,7 @@ div.rich-text:last-child {
   margin: 0 auto;
   max-height: 100vh;
   width: 100%;
+
   video,
   iframe,
   img,
@@ -42,6 +57,7 @@ div.rich-text:last-child {
     max-height: 100vh;
     overflow: hidden;
   }
+
   video,
   iframe {
     z-index: 1;


### PR DESCRIPTION
 add styles to apply max-width to rich text images when aligned left/right to give content managers ability to add thumbnails

 Changes to be committed:
	modified:   app/assets/_dev/scss/base/_article_page.scss
	modified:   app/assets/_dev/scss/base/_site.scss