### PR TITLE
Vendor in the NHS Promo content

### DIFF
--- a/app/assets/_dev/scss/promo.scss
+++ b/app/assets/_dev/scss/promo.scss
@@ -1,0 +1,151 @@
+/* ==========================================================================
+   COMPONENTS / #PROMO
+   ========================================================================== */
+
+/**
+ * 1. Extra margin is added to compensate for the box-shadow.
+ * 2. Box shadow size is set within settings/_globals.scss.
+ * 3. Makes the <a> fill the height of it's parent container.
+ * 4. Is needed for the :active top positioning.
+ * 5. Removes default <a> text underline from all elements.
+ * 6. Adds text underline to promo heading.
+ * 7. Creates the 'pressed down' effect when clicked.
+ * 8. Border is used to create a divider between the white content
+ *    box and an image.
+ */
+
+ .nhsuk-promo {
+  margin-bottom: nhsuk-spacing(5) + $nhsuk-box-shadow-link; /* [1] */
+  width: 100%;
+}
+
+.nhsuk-promo__link-wrapper {
+  background-color: $color_nhsuk-white;
+  border: 1px solid transparent;
+  box-shadow: 0 $nhsuk-box-shadow-link 0 0 $color_nhsuk-grey-4; /* [2] */
+  display: block;
+  height: 100%; /* [3] */
+  position: relative; /* [4] */
+  text-decoration: none; /* [5] */
+
+  &:hover {
+    background-color: $color_nhsuk-white;
+    color: $color_nhsuk-blue;
+
+    .nhsuk-promo__heading {
+      color: $nhsuk-link-hover-color;
+    }
+  }
+
+  &:focus {
+    background-color: $color_nhsuk-white;
+    box-shadow: 0 $nhsuk-box-shadow-link 0 0 $color_nhsuk-grey-4;
+
+    .nhsuk-promo__heading {
+      @include nhsuk-focused-text();
+    }
+
+  }
+
+  &:active {
+    background-color: $color_nhsuk-white; /* [7] */
+    box-shadow: none;
+    top: $nhsuk-box-shadow-link; /* [7] */
+
+    .nhsuk-promo__heading {
+      background: none;
+      box-shadow: none;
+    }
+  }
+
+  &:hover,
+  &:active {
+    .nhsuk-promo__heading {
+      text-decoration: none;
+    }
+  }
+
+}
+
+.nhsuk-promo__img {
+  @include print-hide();
+
+  border-bottom: 1px solid $color_nhsuk-grey-5; /* [8] */
+  display: block;
+  width: 100%;
+
+}
+
+.nhsuk-promo__heading {
+  @include nhsuk-font(24, $weight: bold);
+
+  display: inline-block;
+  margin-bottom: nhsuk-spacing(3);
+  text-decoration: underline;
+}
+
+.nhsuk-promo__content {
+  @include top-and-bottom();
+  @include nhsuk-responsive-padding(5);
+}
+
+.nhsuk-promo__description {
+  color: $nhsuk-secondary-text-color;
+}
+
+/* Promo size variant
+   ========================================================================== */
+
+/**
+ * Promo small reduces the size of the text heading and description.
+ */
+
+.nhsuk-promo--small {
+
+  .nhsuk-promo__heading {
+    @include nhsuk-typography-responsive(19);
+  }
+
+  .nhsuk-promo__description {
+    @include nhsuk-typography-responsive(16);
+  }
+
+}
+
+/* Promo group
+   ========================================================================== */
+
+/**
+ * Promo group allows you to have a row of promos.
+ *
+ * Flexbox is used to make each promo in a row the same height.
+ */
+
+.nhsuk-promo-group {
+  @include flex();
+
+  margin-bottom: nhsuk-spacing(5) + $nhsuk-box-shadow-link;
+
+  @include mq($until: desktop) {
+    margin-bottom: nhsuk-spacing(4) + $nhsuk-box-shadow-link;
+  }
+
+}
+
+.nhsuk-promo-group__item {
+  @include flex-item();
+
+  @include mq($until: desktop) {
+    margin-bottom: nhsuk-spacing(4) + $nhsuk-box-shadow-link;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+  }
+
+  .nhsuk-promo {
+    margin-bottom: 0;
+  }
+
+}

--- a/app/assets/_dev/scss/screen.scss
+++ b/app/assets/_dev/scss/screen.scss
@@ -2,6 +2,8 @@
 @import "nhsuk-frontend/packages/nhsuk";
 
 // Main CSS
+@import "promo";
+
 @import "helpers/_mixins";
 
 @import "settings/_colours";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,11 @@
       }
     },
     "nhsuk-frontend": {
-      "version": "github:dxw/nhsuk-frontend#ecfaadb04a762967455d071cc74d892c415dd5fc",
-      "from": "github:dxw/nhsuk-frontend",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-Qg/2O72XeHkyzMnEV58bvrYb9Wg0QcoTIZgBAa8B0ch6yO0rW+u6tNv3eD2fSkQ8NLBGWVRmdBAXGtcn1xMQZw==",
       "requires": {
-        "accessible-autocomplete": "^2.0.2"
+        "accessible-autocomplete": "^2.0.3"
       }
     },
     "preact": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/dxw/nhsx-website#readme",
   "dependencies": {
-    "nhsuk-frontend": "dxw/nhsuk-frontend"
+    "nhsuk-frontend": "^4.1.0"
   }
 }


### PR DESCRIPTION
We rely quite heavily on the NHS promo component. This has been removed in version `> 4.x` of NHSUK Frontend, and the styles have appeared a little broken for a while. As a quick fix, we're vendoring in the component our end, until we can put in a more permenant fix.