### PR TITLE
Suppress pytest warnings about deprecations in libraries

### DIFF
--- a/script/test
+++ b/script/test
@@ -7,4 +7,4 @@ if [ $# -eq 0 ]; then
 fi
 
 echo "Running tests..."
-docker-compose run --rm web pytest "$@"
+docker-compose run --rm web pytest --disable-pytest-warnings "$@"


### PR DESCRIPTION
I keep looking at these voluminous warnings and they're never
useful or actionable, and make actually looking for the error in
the logs really hard.
