### PR TITLE
Address Finder meeting issues

### DIFF
--- a/app/modules/finder/blocks.py
+++ b/app/modules/finder/blocks.py
@@ -18,9 +18,9 @@ class FinderBlock(TableBlock):
         # if the first row is a header, we skip it (offset=1) otherwise we don't (offset=0)
         # and we get the second column (row[1]) and use it as a facet
         # and ignore None values (if row[1])
-        context["context"]["facets"] = sorted(
-            list(set([row[1] for row in data[offset:] if row[1]]))
-        )
+        all_facets = [row[1] for row in data[offset:] if row[1]]
+        context["context"]["facets"] = list(dict.fromkeys(all_facets))
+
         return super().render(value, **context)
 
     class Meta:

--- a/app/templates/finder/blocks/finder_block.html
+++ b/app/templates/finder/blocks/finder_block.html
@@ -230,8 +230,10 @@
         var query = frm.inpSearch.value;
         var facet = frm.facetSelect.value;
 
-        // Filter the table
-        tf.setFilterValue(0, "*"+query); // column 0, * = contains
+        // Filter the table with all words
+        and_query = query.replace(/ /g, ' && *')
+
+        tf.setFilterValue(0, "*"+and_query); // column 0, * = contains
         tf.setFilterValue(1, "*"+facet);
         tf.filter();
 

--- a/app/templates/finder/blocks/finder_block.html
+++ b/app/templates/finder/blocks/finder_block.html
@@ -157,6 +157,7 @@
     </div>
 
       <button type="submit" class="nhsuk-button">Search</button>
+      <p><a href="javascript:reset()">clear search</a></p>
 </form>
 
 <div class="table-wrapper" tabindex=0>
@@ -216,6 +217,13 @@
 <script src="/static/_dev/tablefilter/tablefilter.js"></script>
 
 <script>
+
+        function reset(evt){
+          var frm = document.getElementById('finderform');
+          frm.inpSearch.value="";
+          frm.facetSelect.value="";
+          filter(evt);
+        }
         // Form submission logic for filtering the table
         function filter(evt){
         var frm = document.getElementById('finderform');
@@ -228,7 +236,7 @@
         tf.filter();
 
         // Prevent form submission
-        evt.preventDefault();
+        if (evt) {evt.preventDefault()};
     };
 </script>
 

--- a/app/templates/finder/blocks/finder_block.html
+++ b/app/templates/finder/blocks/finder_block.html
@@ -21,6 +21,7 @@
       table {
 	border-collapse: collapse;
 	border-spacing: 0;
+  border-top: 2px solid grey;
       }
 	
       caption { 
@@ -141,7 +142,11 @@
 
     <div class="nhsuk-form-group">
         <label class="nhsuk-label" for="facetselect">
-        Record type:
+          {% if table_header %} 
+            {{data.0.1}}:
+          {% else %}
+            Category:
+          {% endif %}
         </label>
       <select class="nhsuk-select" id="facetSelect" name="facetSelect">
         <option value="" selected>All</option>

--- a/app/templates/finder/blocks/finder_block.html
+++ b/app/templates/finder/blocks/finder_block.html
@@ -245,6 +245,9 @@
 <script data-config>
     var filtersConfig = {
         base_path: '/static/_dev/tablefilter/',
+        single_filter: {exclude_cols: [],
+                        css_class: 'nhsuk-input',
+                        auto_filter: {delay: 100}}
         //grid: false,  // turn off search-per-column
         // auto_filter: {delay: 100 }, // milliseconds -- works with original filter
         // highlight_keywords: true, // feels good but renders terribly


### PR DESCRIPTION
I can see how I’d modify the JavaScript source to search across different cells, but not how to minify and package it afterwards.
at line 1587 in unminified tablefilter.js, we could pass something like a string concatenation of row.cells or all the values of cells[j], so we’re searching over one text.

* reset link
* Category not Record Type (or second title)
* Line above table
* A and B and C
* on any (single) cell (can't cross cells :( )