### PR TITLE
Fix left/right align in images in richtext

### DIFF
--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -21,9 +21,14 @@ img.full-width {
 img.richtext-image {
 
   // full width already catered for above
-  &.left,
+  &.left {
+    max-width: 280px;
+    float: left;
+  }
+
   &.right {
     max-width: 280px;
+    float: right;
   }
 }
 


### PR DESCRIPTION
There are float:left and float:right in hallo.css but not in _site.scss -- fixed, but this might hint at a bigger problem.