### PR TITLE
Ensure only live pages are visible in other pages' templates

### DIFF
--- a/app/templates/ai_lab/resource.html
+++ b/app/templates/ai_lab/resource.html
@@ -14,7 +14,7 @@
       <div class="nhsai-resource__meta nhsuk-grid-column-two-thirds">
         <h1 class="nhsuk-heading-xl">{{ page.title }}</h1>
 
-        {% for pub in page.get_children %}
+        {% for pub in page.get_children.live %}
         <div class="nhsuk-action-link">
           <a class="nhsuk-action-link__link" href="{{pub.url}}">
             <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 384 512" aria-hidden="true">

--- a/app/templates/ig_guidance/ig_template.html
+++ b/app/templates/ig_guidance/ig_template.html
@@ -14,7 +14,7 @@
       <div class="nhsai-resource__meta nhsuk-grid-column-two-thirds">
         <h1 class="nhsuk-heading-xl">{{ page.title }}</h1>
 
-        {% for pub in page.get_children %}
+        {% for pub in page.get_children.live %}
         <div class="nhsuk-action-link">
           <a class="nhsuk-action-link__link" href="{{pub.url}}">
             <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 384 512" aria-hidden="true">

--- a/app/templates/ig_guidance/internal_guidance.html
+++ b/app/templates/ig_guidance/internal_guidance.html
@@ -20,7 +20,7 @@
       <div class="nhsai-resource__meta nhsuk-grid-column-two-thirds">
         <h1 class="nhsuk-heading-xl">{{ page.title }}</h1>
 
-        {% for pub in page.get_children %}
+        {% for pub in page.get_children.live %}
         <div class="nhsuk-action-link">
           <a class="nhsuk-action-link__link" href="{{pub.url}}">
             <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 384 512" aria-hidden="true">

--- a/app/templates/people/people_listing_page.html
+++ b/app/templates/people/people_listing_page.html
@@ -16,7 +16,7 @@
           <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">{{ page.title }}</h1>
           {{ page.body }}
 
-          {% for group in page.get_children.specific|chunk:4 %}
+          {% for group in page.get_children.live.specific|chunk:4 %}
           <div class="nhsuk-grid-row">
             {% for person in group %}
             {% include 'people/_partials/person.html' with person=person %}


### PR DESCRIPTION
https://dxw.zendesk.com/agent/tickets/14394

We'd probably fixed the issues with the python code, but templates also have calls to get_children which needs .live() to exclude unpublished documents.