### PR TITLE
Ensure text after an image isn't before it. Add horizontal padding.

### DIFF
--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -24,13 +24,27 @@ img.richtext-image {
   &.left {
     max-width: 280px;
     float: left;
+    clear: right;
+    margin-right: 0.5rem;
   }
 
   &.right {
     max-width: 280px;
     float: right;
+    clear: left;
+    margin-left: 0.5rem;
   }
 }
+
+img.richtext-image.left + p {
+  clear: right;
+}
+
+img.richtext-image.right + p {
+  clear: left;
+}
+
+
 
 div.rich-text:last-child {
   p {


### PR DESCRIPTION
After <img width="782" alt="Screenshot 2021-09-01 at 13 57 50" src="https://user-images.githubusercontent.com/85497046/131678302-51746f4f-07d7-4272-9bbe-e007474cdb7c.png">

Before <img width="791" alt="Screenshot 2021-09-01 at 11 37 39" src="https://user-images.githubusercontent.com/85497046/131678334-478a82c6-00b5-44d4-b386-704a6426dfab.png">
