### PR TITLE
Responsive CSS - centre images on small screens and don't float

### DIFF
--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -17,22 +17,37 @@ img.full-width {
 //Some max-width for images in rich-text
 //Ideally this should be done in the wagtail-nhsuk-frontend package
 //But not possible at this time
+@media (min-width: 560px) {
+  img.richtext-image.left {
+    float: left;
+    clear: right;
+    margin-right: 0.5rem;
+  }
+  img.richtext-image.right {
+    float: right;
+    clear: left;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (max-width: 559.99px) {
+  img.richtext-image.left,
+  img.richtext-image.right {
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+  }
+}
 
 img.richtext-image {
 
   // full width already catered for above
   &.left {
     max-width: 280px;
-    float: left;
-    clear: right;
-    margin-right: 0.5rem;
   }
 
   &.right {
     max-width: 280px;
-    float: right;
-    clear: left;
-    margin-left: 0.5rem;
   }
 }
 


### PR DESCRIPTION
<img width="281" alt="Screenshot 2021-09-01 at 17 21 06" src="https://user-images.githubusercontent.com/85497046/131708428-4ea2fb24-9675-4bbd-8754-2b722d8125ba.png">
