### PR TITLE
Remove print statements

### DIFF
--- a/app/modules/ai_lab/tests/test_ai_lab_resource.py
+++ b/app/modules/ai_lab/tests/test_ai_lab_resource.py
@@ -151,5 +151,4 @@ class TestAiLabResource:
         case_study = AiLabCaseStudyFactory.create(parent=category_page)
         publication = PublicationFactory.create(parent=case_study, title="ocelot")
         page = client.get(case_study.url)
-        print(page.content)
         assert "ocelot" in str(page.rendered_content)

--- a/app/modules/ig_guidance/tests/test_guidance.py
+++ b/app/modules/ig_guidance/tests/test_guidance.py
@@ -114,5 +114,4 @@ class TestGuidance:
         )
         publication = PublicationFactory.create(parent=template, title="panther")
         page = client.get(template.url)
-        print(page.content)
         assert "panther" in str(page.rendered_content)

--- a/app/modules/publications/models.py
+++ b/app/modules/publications/models.py
@@ -79,7 +79,6 @@ class PublicationPage(BasePage, CanonicalMixin):
         header_tags = ["h2"]
         toc = []
         # NOTE: we import as HTML because we don't have a wrapping tag
-        print(html, type(html))
         root = lxml.html.fromstring(html)
         for tag_name in header_tags:
             for tag in root.xpath(f"//{tag_name}"):

--- a/app/modules/publications/tests/fixtures.py
+++ b/app/modules/publications/tests/fixtures.py
@@ -41,7 +41,6 @@ def _create_publication_index_page(title: str, parent: Page) -> PublicationIndex
         PublicationIndexPage: Description
     """
     p = PublicationIndexPage()
-    print(p.get_children())
     p.title = title
     parent.add_child(instance=p)
     p.save_revision().publish()


### PR DESCRIPTION
Solarwinds is using over its prepaid amount; let's reduce unnecessary logging.