### PR TITLE
Merge no_spool_temp_file to master

### DIFF
--- a/app/helpers/storage.py
+++ b/app/helpers/storage.py
@@ -1,5 +1,5 @@
 import os
-from tempfile import SpooledTemporaryFile
+from tempfile import TemporaryFile
 from django.core.exceptions import SuspiciousOperation
 
 from storages.backends.s3boto3 import S3Boto3Storage
@@ -70,7 +70,7 @@ class MediaRootS3BotoStorage(S3Boto3Storage):
         # Create a temporary file that will write to disk after a specified
         # size. This file will be automatically deleted when closed by
         # boto3 or after exiting the `with` statement if the boto3 is fixed
-        with SpooledTemporaryFile() as content_autoclose:
+        with TemporaryFile() as content_autoclose:
 
             # Write our original content into our copy that will be closed by boto3
             content_autoclose.write(content.read())


### PR DESCRIPTION
The following 500 error was occurring on image upload:
File /usr/srv/app/./helpers/storage.py line 80 in _save args locals
  return super(MediaRootS3BotoStorage, self)._save(name, content_autoclose)
File /usr/lib/python3.8/site-packages/storages/backends/s3boto3.py line 466 in _save args locals
  if content.seekable():
AttributeError: 'SpooledTemporaryFile' object has no attribute 'seekable'

STF does not expose the seekable attribute, a known deficiency.
https://bugs.python.org/issue26175

I was unable to reproduce this error locally, probably because I'm not saving to S3.