### PR TITLE
Alpine 2.14 not on prod

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -187,7 +187,7 @@ DATABASES = {
 
 WAGTAILSEARCH_BACKENDS = {
     "default": {
-        "BACKEND": "wagtail.contrib.postgres_search.backend",
+        "BACKEND": "wagtail.search.backends.database",
         "SEARCH_CONFIG": "english",
         "AUTO_UPDATE": True,
     }

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -280,6 +280,7 @@ WAGTAIL_SITE_NAME = "NHSX"
 WAGTAILEMBEDS_FINDERS = [
     {
         "class": "helpers.finders.OSMFinder",
+        "class": "wagtail.embeds.finders.oembed"
         # Any other options will be passed as kwargs to the __init__ method
     }
 ]


### PR DESCRIPTION
When updating to Alpine 2.14, some of those changes were not reflected in `Dockerfile-prod`.

The dev/prod dockerfiles have a number of differences, many of which aren't obviously necessary, so further work may be needed.