### PR TITLE
Add parent section title to HTML title tag

### DIFF
--- a/app/templates/_partials/head_meta.html
+++ b/app/templates/_partials/head_meta.html
@@ -3,8 +3,9 @@
 <meta charset="utf-8" />
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <title>
-    {% block title_prefix %}{{ TITLE_PREFIX }}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}
-    - NHSX{% endblock %}</title>
+    {% block title_prefix %}{{ TITLE_PREFIX }}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% if page.get_parent.content_type.name == 'section page' %} - {{page.get_parent.title}}{% endif %}{% block title_suffix %}
+    - NHSX{% endblock %}
+</title>
 <meta name="description"
     content="{% if page.search_description %}{{ page.search_description }}{% else %}{{ page|fb_og_description:request }}{% endif %}" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
If the parent of the current page is a Section Page, add its title
to the middle of the HTML title tag for the current page.

This works alright on `/` because there's a fake page above it (and it'd
probably fail silently anyway)

https://dxw.zendesk.com/agent/tickets/13031