### PR TITLE
Use nhsx-dark-grey, not nhs-dark-grey for reorg banner

### DIFF
--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -106,7 +106,7 @@ div.rich-text:last-child {
 
 .rebrand-banner {
   background-color: $nhsx-pale-grey;
-  color: $nhs-dark-grey;
+  color: $nhsx-dark-grey;
   font-size: 19px;
   width: 100vw;
   padding-bottom: 24px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/85497046/152575957-b282ea91-9352-4aa6-aa54-676935458098.png)
After:
![image](https://user-images.githubusercontent.com/85497046/152576020-59e13f58-eac7-431e-acb6-a1bbee5b79ac.png)
