### PR TITLE
Remove closure-compiler

### DIFF
--- a/app/config/assets.py
+++ b/app/config/assets.py
@@ -9,15 +9,12 @@ LIBSASS = get_filter(
 
 uglify_js = get_filter("uglifyjs", extra_args=["--source-map", "-c", "-m"])
 
-
-closure_js = get_filter("closure_js")
+js_filters: list = []
 
 if settings.DEBUG:
     css_filters = [LIBSASS]
-    js_filters: list = []
 else:
     css_filters = [LIBSASS, "cssmin"]
-    js_filters = [closure_js]
 
 core_css_files = ["_dev/scss/screen.scss"]
 
@@ -48,12 +45,10 @@ css_admin_bundle = Bundle(
     output="dist/css/admin_extra.min.css"
 )
 
-js_core_bundle = Bundle(
-    *core_js_files, filters=[closure_js], output="dist/js/main.min.js"
-)
+js_core_bundle = Bundle(*core_js_files, filters=[], output="dist/js/main.min.js")
 
 js_admin_bundle = Bundle(
-    *admin_js_files, filters=[closure_js], output="dist/js/admin_extra.min.js"
+    *admin_js_files, filters=[], output="dist/js/admin_extra.min.js"
 )
 
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -50,9 +50,6 @@ RUN apk update && apk add --no-cache \
 # Install static asset compilers
 ####################################################################################################
 
-RUN apk add closure-compiler --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
-    rm -f /tmp/* /etc/apk/cache/* /root/.cache
-
 # work around a bug in the version of node we are using
 # https://github.com/npm/uid-number/issues/3
 # https://github.com/nodejs/docker-node/issues/813

--- a/docker/web/Dockerfile-prod
+++ b/docker/web/Dockerfile-prod
@@ -51,9 +51,6 @@ RUN apk update && apk add --no-cache \
 # Install static asset compilers
 ####################################################################################################
 
-RUN apk add closure-compiler --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
-    rm -f /tmp/* /etc/apk/cache/* /root/.cache
-
 # work around a bug in the version of node we are using
 # https://github.com/npm/uid-number/issues/3
 # https://github.com/nodejs/docker-node/issues/813


### PR DESCRIPTION
Docker build and CI were broken with the error message:

```
Step 5/31 : RUN apk add closure-compiler --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted &&     rm -f /tmp/* /etc/apk/cache/* /root/.cache
 ---> Running in 550968f4fc23
fetch http://dl-3.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  closure-compiler (no such package):
    required by: world[closure-compiler]
```

The closure-compiler does not appear to obviously be used anywhere, so we have removed this dependency.

There are links in Google search to https://pkgs.alpinelinux.org/package/edge/testing/x86/closure-compiler
with text suggesting a v20171203-r1 version existed, but the page itself 404s. A link does exist in the
AUR (https://aur.archlinux.org/packages/closure-compiler)