### PR TITLE
Update Poetry to 1.2.2

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -77,7 +77,8 @@ RUN curl -s https://raw.githubusercontent.com/envkey/envkey-source/master/instal
 ENV POETRY_VIRTUALENVS_CREATE=0 \
     POETRY_VIRTUALENVS_IN_PROJECT=0 \
     POETRY_VIRTUALENVS_PATH="/usr/venvs" \
-    POETRY_REPOSITORIES={}
+    POETRY_REPOSITORIES={} \
+    POETRY_VERSION=1.2.2
 
 # Attempting to fix issues with broken pip installs -- something like:
 # ImportError: cannot import name 'InvalidSchemeCombination' from 'pip._internal.exceptions'
@@ -93,8 +94,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /tmp/* /etc/apk/cache/* /root/.cache
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && \
-    source $HOME/.poetry/env
+RUN curl -sSL https://install.python-poetry.org | python
 
 RUN mkdir -p /usr/srv/app/
 WORKDIR /usr/srv/app/
@@ -123,9 +123,8 @@ RUN mv ./node_modules/ /usr/srv/deps
 # POETRY (working and installed in django-base)
 COPY ./app/pyproject.toml /usr/srv/app/pyproject.toml
 COPY ./app/poetry.lock /usr/srv/app/poetry.lock
-RUN source $HOME/.poetry/env && \
-    poetry self update && \
-    poetry install
+RUN $HOME/.local/bin/poetry self update && \
+    $HOME/.local/bin/poetry install
 
 
 VOLUME /usr/srv/app/media

--- a/docker/web/Dockerfile-prod
+++ b/docker/web/Dockerfile-prod
@@ -75,7 +75,8 @@ FROM base AS app
 ENV POETRY_VIRTUALENVS_CREATE=0 \
     POETRY_VIRTUALENVS_IN_PROJECT=0 \
     POETRY_VIRTUALENVS_PATH="/usr/venvs" \
-    POETRY_REPOSITORIES={}
+    POETRY_REPOSITORIES={} \
+    POETRY_VERSION=1.2.2
 
 # Attempting to fix issues with broken pip installs -- something like:
 # ImportError: cannot import name 'InvalidSchemeCombination' from 'pip._internal.exceptions'
@@ -91,8 +92,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /tmp/* /etc/apk/cache/* /root/.cache
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && \
-    source $HOME/.poetry/env
+RUN curl -sSL https://install.python-poetry.org | python
 
 RUN mkdir -p /usr/srv/app/
 WORKDIR /usr/srv/app/
@@ -120,9 +120,8 @@ RUN mkdir -p /usr/srv/deps
 RUN mv ./node_modules/ /usr/srv/deps
 
 # POETRY (working and installed in django-base)
-RUN source $HOME/.poetry/env && \
-    poetry self update && \
-    poetry install
+RUN $HOME/.local/bin/poetry self update && \
+    $HOME/.local/bin/poetry install
 
 
 


### PR DESCRIPTION
The old poetry installer is being deprecated which led to the builds being broken.
We need to migrate to the new installer which uses a different install directory. 