### PR TITLE
Check migrations exist before committing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,11 @@ repos:
     hooks:
       - id: dockerfilelint
         stages: [commit]
+  - repo: local
+    hooks:
+      - id: pre-commit-django-migrations
+        name: Check django migrations
+        entry: script/manpy makemigrations --check --dry-run
+        language: system
+        types: [python]
+        pass_filenames: false


### PR DESCRIPTION
Add a precommit hook which checks that the migrations are up-to-date before committing.