### PR TITLE
Modify migration dependency

### DIFF
--- a/app/modules/core/migrations/0048_analyticssettings_ga4_id.py
+++ b/app/modules/core/migrations/0048_analyticssettings_ga4_id.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0046_auto_20210902_1250'),
+        ('core', '0047_nhsuk_frontend_panels'),
     ]
 
     operations = [


### PR DESCRIPTION
This commit modifies the migration dependency so that it depends on 0047_nhsuk_frontend_panels rather than 0046_auto_20210902_1250, this is to resolve a conflict whjen running the migration on the stage instance