### PR TITLE
disable frontend migration migration

### DIFF
--- a/app/modules/core/migrations/0047_nhsuk_frontend_panels.py
+++ b/app/modules/core/migrations/0047_nhsuk_frontend_panels.py
@@ -12,6 +12,7 @@ from wagtail.core.models import PageRevision
 # With great thanks to Andy Babic for explaining how to migrate
 # https://wagtailcms.slack.com/archives/C81FGJR2S/p1658748123806079
 
+""" 
 from modules.meeting_minutes.models import  MeetingMinutes, MeetingMinutesListingPage
 from modules.home.models import HomePage
 from modules.blog_posts.models import BlogPost, BlogPostIndexPage
@@ -26,8 +27,10 @@ from modules.news.models import News, NewsIndexPage
 from modules.people.models import Person, PeopleListingPage
 # Template may be wrong
 from modules.ig_guidance.models import IGGuidance, GuidanceListingPage, InternalGuidance, ExternalGuidance, IGTemplate
-from modules.case_studies. models import CaseStudyPage
+from modules.case_studies. models import CaseStudyPage 
+"""
 
+""" 
 all_page_types = [
    # MeetingMinutes -- no body
    MeetingMinutesListingPage,
@@ -47,7 +50,8 @@ HomePage,
  GuidanceListingPage, InternalGuidance, ExternalGuidance, IGTemplate,
  CaseStudyPage,
 
-]
+] 
+"""
 
 
 
@@ -183,7 +187,8 @@ class Migration(migrations.Migration):
     dependencies = [
         ('core', '0046_auto_20210902_1250'),
     ]
-
+'''
     operations = [
         migrations.RunPython(forwards, backwards)
     ]
+'''


### PR DESCRIPTION
This commit idabled migration 0047_nhsuk_frontend_panels.py so that it is not executed when applying migrations, so that the currently dev branch can be deployed to prod safely.

TODO:
ensure a future version depends on all migration types (e.g. publications, minutes, etc.)
fix the broken migration that does not insert any of the content from the actual panel.