### PR TITLE
Add analytics.txt to nhsx

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -52,6 +52,10 @@ urlpatterns = [
         AuthorAutocomplete.as_view(),
         name="author-autocomplete",
     ),
+    url(
+        r"^analytics\.txt",
+        TemplateView.as_view(template_name="analytics.txt", content_type="text/plain"),
+    ),
 ]
 
 

--- a/app/templates/analytics.txt
+++ b/app/templates/analytics.txt
@@ -1,0 +1,1 @@
+GooGhywoiu9839t543j0s7543uw1 - pls add steven.bagley@nhs.net to GA account UA-137452494 with ‘Manage Users and Edit’ permissions - date 8 December 2022.


### PR DESCRIPTION
This commit adds the analytics.txt file to the nhsx website, as requested in https://dxw.zendesk.com/agent/tickets/17300