### PR TITLE
Disable poetry self-update in docker-compose

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -123,8 +123,8 @@ RUN mv ./node_modules/ /usr/srv/deps
 # POETRY (working and installed in django-base)
 COPY ./app/pyproject.toml /usr/srv/app/pyproject.toml
 COPY ./app/poetry.lock /usr/srv/app/poetry.lock
-RUN $HOME/.local/bin/poetry self update && \
-    $HOME/.local/bin/poetry install
+#RUN $HOME/.local/bin/poetry self update && \
+RUN $HOME/.local/bin/poetry install
 
 
 VOLUME /usr/srv/app/media

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -123,6 +123,7 @@ RUN mv ./node_modules/ /usr/srv/deps
 # POETRY (working and installed in django-base)
 COPY ./app/pyproject.toml /usr/srv/app/pyproject.toml
 COPY ./app/poetry.lock /usr/srv/app/poetry.lock
+## self update disabled currently due to causing timeout issues in the deploy
 #RUN $HOME/.local/bin/poetry self update && \
 RUN $HOME/.local/bin/poetry install
 


### PR DESCRIPTION
This commit disables the poetry self-update command, as this seems to be causing a timeout error when trying to deploy the site to stage.

I have tested this change locally by running script/setup on two fresh instances of the repo, one with the self-update command disabled, and one with it enabled. In these tests I also ran docker-compose build with the --no-cache option, to ensure that cacheing didn't affect things.

the instance with the self-update disabled installed as expected, hopefully this will allow the deploy to stage to complete as expected, but I would expect we will want to revert this change at some point (ie when we are in a position to track the latest stable wagtail releases).

We may need to also implement this change in `dockerfile-prod` as well, if we see the same issue occurring there, but I would rather hold off making that change until we know whether it is necessary.