### PR TITLE
Add http 301 redirects to uWSGI config

### DIFF
--- a/docker/web/conf/uwsgi.ini
+++ b/docker/web/conf/uwsgi.ini
@@ -36,3 +36,14 @@ thread-stacksize = 512
 
 thunder-lock = true
 vacuum = true
+
+# 301 Redirects
+
+# https://dxw.zendesk.com/agent/tickets/17352
+route = /improvement/focusondiagnostics/ redirect-301:/focusondiagnostics/
+# https://dxw.zendesk.com/agent/tickets/17538
+route = /key-tools-and-info/get-started-with-nhsx-digital-and-technology-assurance/ redirect-301:/key-tools-and-info/get-started-with-digital-and-technology-assurance/
+# https://dxw.zendesk.com/agent/tickets/17711
+route = /covid-19-response/technology-nhs/supporting-transformation-through-innovation-collaborative/ redirect-301:/covid-19-response/technology-nhs/innovation-collaborative-for-digital-health/
+route = /covid-19-response/technology-nhs/the-nhsx-national-innovation-collaborative-podcast/ redirect-301:/covid-19-response/technology-nhs/the-innovation-collaborative-podcast/
+route = /ai-lab/ai-lab-programmes/regulating-the-ai-ecosystem/the-multi-agency-advice-service-maas/ redirect-301:/ai-lab/ai-lab-programmes/regulating-the-ai-ecosystem/the-ai-and-digital-regulations-service/


### PR DESCRIPTION
Currently these have been placed in the Dalmatian configuration, because we cannot add redirects via the user interface. However, this is problematic as CloudFront redirections happen via a custom JavaScript function which must run in under 1ms. This means that there will inevitably be a hard limit to how many redirects we can add to the infrastructure.

Adding redirects to the uWSGI configuration at least means that we are not abusing the CloudFront configuration, and we can add more redirects via new PRs.