### PR TITLE
Fix the build

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -2,8 +2,8 @@
 name = "NHSX"
 version = "0.1.0"
 description = "NHSX Wagtail site"
-authors = ["andy@hactar.is"]
-maintainers = ["dragon@dxw.com"]
+authors = ["Andy <andy@hactar.is>"]
+maintainers = ["dragon <dragon@dxw.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -63,5 +63,5 @@ pytest-sugar = "*"
 
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry=1.2.2"]
 build-backend = "poetry.masonry.api"

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -124,7 +124,7 @@ RUN mv ./node_modules/ /usr/srv/deps
 COPY ./app/pyproject.toml /usr/srv/app/pyproject.toml
 COPY ./app/poetry.lock /usr/srv/app/poetry.lock
 ## self update disabled currently due to causing timeout issues in the deploy
-#RUN $HOME/.local/bin/poetry self update && \
+#RUN $HOME/.local/bin/poetry self update 1.2.2 && \
 RUN $HOME/.local/bin/poetry install
 
 

--- a/docker/web/Dockerfile-prod
+++ b/docker/web/Dockerfile-prod
@@ -120,7 +120,7 @@ RUN mkdir -p /usr/srv/deps
 RUN mv ./node_modules/ /usr/srv/deps
 
 # POETRY (working and installed in django-base)
-RUN $HOME/.local/bin/poetry self update && \
+RUN $HOME/.local/bin/poetry self update 1.2.2 && \
     $HOME/.local/bin/poetry install
 
 


### PR DESCRIPTION
The build of the nhsx site was being broken by some incompatible changes which had been made to poetry.

These changes enforce the use of poetry 1.2.2 which works with the pyproject file as currently configured, and should allow the build to complete allowing the site to be deployed again.

to test:
download this branch, and uncomment the line 127 in docker/web/Dockerfile then run script/setup to build the site. confirm that the build completes.

this should confirm that the build as configured in Dockerfile-prod will work as expected.