### PR TITLE
Fix docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   # Postgres
   db:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -127,8 +127,10 @@ COPY ./app/pyproject.toml /usr/srv/app/pyproject.toml
 COPY ./app/poetry.lock /usr/srv/app/poetry.lock
 ## self update disabled currently due to causing timeout issues in the deploy
 #RUN $HOME/.local/bin/poetry self update 1.2.2 && \
-RUN $HOME/.local/bin/poetry install
-
+RUN mkdir -p $HOME/.poetry \
+    && touch $HOME/.poetry/env \
+    && $HOME/.local/bin/poetry install \
+    && ln -s $HOME/.local/bin/poetry /usr/local/bin/poetry
 
 VOLUME /usr/srv/app/media
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -71,7 +71,9 @@ RUN pip install --no-cache-dir \
 FROM base AS app
 
 # Install envkey-source
-RUN curl -s https://raw.githubusercontent.com/envkey/envkey-source/master/install.sh | bash
+RUN set -ex && apk add --no-cache sudo \
+    && curl -s https://raw.githubusercontent.com/envkey/envkey-source/master/install.sh | bash \
+    && apk del sudo
 
 # Install and set up Poetry for python dependencies management
 ENV POETRY_VIRTUALENVS_CREATE=0 \

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker-compose -f docker-compose.test.yml run --rm test
+docker compose -f docker-compose.test.yml run --rm test


### PR DESCRIPTION
FIX the broken build that can be seen on #800 and https://github.com/nhsx/nhsx-website/actions/runs/10491953953/job/29062294843?pr=800

* Use `docker compose` where `docker-compose` is not available
* Dockerfile uses `sudo` package to install `envkey`. The version of Alpine used as the base image here is pinned and the envkey install script has not changed in three years, so it is difficult to see how this broke. However, without installing the sudo package the sudo command in install.sh cannot run and the Dockerfile cannot be built. To ensure that the final image does not change we also remove the sudo package after running the install script.
* Install poetry more defensively Avoid errors when building the Dockerfile by:
    * Creating directories and files that 'poetry install' expects
    * Adding poetry to the current $PATH
* Remove deprecated 'version' from docker-compose

## Testing 

1. Run `./script/test` and check it runs green.
1. Run `./script/server` and check you can see a running site at http://localhost:5000
