### PR TITLE
Do not display Panel Guidance tags on cards

### DIFF
--- a/app/templates/ig_guidance/_partials/guidance.html
+++ b/app/templates/ig_guidance/_partials/guidance.html
@@ -13,7 +13,10 @@
   <div class="nhsuk-promo">
 
     <a href="{{ guidance.url }}" class="nhsuk-promo__link-wrapper">
+
+      {% if guidance.guidance_type != "Panel Guidance" %}
       <span class="nhsai_resource__category">{{ guidance|guidance_type }}</span>
+      {% endif %}
 
       {% if guidance.featured_image %}
       <div class="nhsuk-promo__img_wrapper">


### PR DESCRIPTION
On archive pages the "Panel Guidance" tag should no longer appear as a banner over cards.

See: https://dxw.zendesk.com/agent/tickets/20084

## Testing

You can validate some of this PR by going to a page like:

https://transform.england.nhs.uk/information-governance/guidance/

and using dev tools to delete an HTML element like `<span class="nhsai_resource__category">...</span>`

You can also use `git grep nhsai_resource__category` to check where the element we're deleting appears in the site source.

On staging we can test this page: https://web.staging.nhsx-website.dalmatian.dxw.net/information-governance/guidance/