### PR TITLE
Use the correct property in the test for the logic to function

### DIFF
--- a/app/templates/ig_guidance/_partials/guidance.html
+++ b/app/templates/ig_guidance/_partials/guidance.html
@@ -13,8 +13,7 @@
   <div class="nhsuk-promo">
 
     <a href="{{ guidance.url }}" class="nhsuk-promo__link-wrapper">
-
-      {% if guidance.guidance_type != "Panel Guidance" %}
+      {% if guidance.content_type.name != "Panel Guidance" %}
       <span class="nhsai_resource__category">{{ guidance|guidance_type }}</span>
       {% endif %}
 


### PR DESCRIPTION
This commit modifies the logic to use the correct property of the object to allow the test to function as expected

To Test:
- locally have a guidance listing page and an ig_guidance page of the type Panel Guidance and an ig_guidance page of another type (eg external)
- load the guidance listing page
- confirm that there is no label 'Panel Guidance' in the panel guidance page's card
- confirm that the expected label is displayed on the card for the page that has a different type