### PR TITLE
Prod Release 20240910

### DIFF
--- a/app/templates/ig_guidance/_partials/guidance.html
+++ b/app/templates/ig_guidance/_partials/guidance.html
@@ -13,8 +13,7 @@
   <div class="nhsuk-promo">
 
     <a href="{{ guidance.url }}" class="nhsuk-promo__link-wrapper">
-
-      {% if guidance.guidance_type != "Panel Guidance" %}
+      {% if guidance.content_type.name != "Panel Guidance" %}
       <span class="nhsai_resource__category">{{ guidance|guidance_type }}</span>
       {% endif %}
 

--- a/app/templates/ig_guidance/_partials/guidance.html
+++ b/app/templates/ig_guidance/_partials/guidance.html
@@ -13,7 +13,10 @@
   <div class="nhsuk-promo">
 
     <a href="{{ guidance.url }}" class="nhsuk-promo__link-wrapper">
+
+      {% if guidance.guidance_type != "Panel Guidance" %}
       <span class="nhsai_resource__category">{{ guidance|guidance_type }}</span>
+      {% endif %}
 
       {% if guidance.featured_image %}
       <div class="nhsuk-promo__img_wrapper">


### PR DESCRIPTION
This release changes the display of Internal guidance cards in the guidance listing archive, so that the label on the card is only displayed if the child page is *not* a Panel Guidance type page