### PR TITLE
Redirect job opportunities

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1102,6 +1102,14 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21312
+    url(
+        r"^about-us/working-for/job-opportunities/$",
+        lambda request: redirect(
+            r"https://www.england.nhs.uk/about/working-for/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21312

## Testing

Spin up the live site. Note I needed the following change:

```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```

Check this URL in your browser: http://localhost:5001/about-us/working-for/job-opportunities/ which should redirect to a page on NHS England.