### PR TITLE
Amend digital blueprint redirects

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1076,13 +1076,14 @@ urlpatterns = [
         ),
     ),
     # https://dxw.zendesk.com/agent/tickets/21265
+    # https://dxw.zendesk.com/agent/tickets/21321 (amends)
     #
     # NOTE: This redirect captures all child pages (around 300 of them) as
     # directed by the client in the above ticket.
     url(
         r"^key-tools-and-info/digital-playbooks/",
         lambda request: redirect(
-            r"https://digital.nhs.uk/services/blueprinting/",
+            r"https://www.england.nhs.uk/digitaltechnology/blueprinting/",
             permanent=True,
         ),
     ),


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21321


## Testing

Spin up the live site. Note I needed the following change:

```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```

Check this URL in your browser: http://localhost:5001/akey-tools-and-info/digital-playbooks/ which should redirect to a page on NHS England.