### PR TITLE
Redirect digital screening page

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1111,6 +1111,14 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21358
+    url(
+        r"^key-tools-and-info/digital-screening/$",
+        lambda request: redirect(
+            r"https://www.digital-prevention-services.nhs.uk/screening/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21358

## Testing

Spin up the live site with `./script/server`. 

Note I needed the following change:

```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```

Check this URL in your browser: http://localhost:5001/key-tools-and-info/digital-screening/ which should redirect to a page on the digital prevention services site.