### PR TITLE
Add redirects to NHS England

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1119,6 +1119,28 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21370
+    url(
+        r"^key-tools-and-info/a-guide-to-setting-up-technology-enabled-virtual-wards/$",
+        lambda request: redirect(
+            r"https://www.england.nhs.uk/long-read/a-guide-to-setting-up-technology-enabled-virtual-wards/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^covid-19-response/technology-nhs/virtual-wards-enabled-by-technology-guidance-on-selecting-and-procuring-a-technology-platform/$",
+        lambda request: redirect(
+            r"https://www.england.nhs.uk/long-read/virtual-wards-enabled-by-technology-guidance-on-selecting-and-procuring-a-technology-platform/#appendix-1-the-moscow-approach",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^information-governance/guidance/virtual-wards/$",
+        lambda request: redirect(
+            r"https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
https://dxw.zendesk.com/agent/tickets/21370

## Testing

1. Run the local env with `./script/server`, note you may need this change first:
```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```
1. Check URLs from the redirects, i.e. (note the port)
    * http://localhost:5001/key-tools-and-info/a-guide-to-setting-up-technology-enabled-virtual-wards/
    * http://localhost:5001/covid-19-response/technology-nhs/virtual-wards-enabled-by-technology-guidance-on-selecting-and-procuring-a-technology-platform/
    * http://localhost:5001/information-governance/guidance/virtual-wards/