### PR TITLE
Redirect to Digital NHS Opensafely page

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1096,10 +1096,11 @@ urlpatterns = [
         ),
     ),
     # https://dxw.zendesk.com/agent/tickets/21285
+    # Modified in: https://dxw.zendesk.com/agent/tickets/21396
     url(
         r"^key-tools-and-info/data-saves-lives/improving-care-through-research-and-innovation/opensafely-secure-access-to-data-to-deepen-our-understanding-of-covid-19/$",
         lambda request: redirect(
-            r"/key-tools-and-info/data-saves-lives/improving-care-through-research-and-innovation/expansion-of-opensafely-secure-research-platform/",
+            r"https://digital.nhs.uk/data-and-information/data-tools-and-services/data-services/opensafely/expansion-of-opensafely-secure-research-platform",
             permanent=True,
         ),
     ),
@@ -1138,6 +1139,14 @@ urlpatterns = [
         r"^information-governance/guidance/virtual-wards/$",
         lambda request: redirect(
             r"https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/",
+            permanent=True,
+        ),
+    ),
+    # https://dxw.zendesk.com/agent/tickets/21396
+    url(
+        r"^key-tools-and-info/data-saves-lives/improving-care-through-research-and-innovation/expansion-of-opensafely-secure-research-platform/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/data-and-information/data-tools-and-services/data-services/opensafely/expansion-of-opensafely-secure-research-platform",
             permanent=True,
         ),
     ),


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21396


## Testing

1. Run the local env with `./script/server`, note you may need this change first:
```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```
1. Check URLs from the redirects, i.e. (note the port)
    * http://localhost:5001/key-tools-and-info/data-saves-lives/improving-care-through-research-and-innovation/opensafely-secure-access-to-data-to-deepen-our-understanding-of-covid-19/
    * http://localhost:5001/key-tools-and-info/data-saves-lives/improving-care-through-research-and-innovation/expansion-of-opensafely-secure-research-platform/