### PR TITLE
Redirect analytics internship pages

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1150,6 +1150,21 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21422
+    url(
+        r"^key-tools-and-info/nhsx-analytics-unit/apply-for-nhsx-analytics-unit-internship/$",
+        lambda request: redirect(
+            r"https://nhsengland.github.io/datascience/PhDInterns/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/nhsx-analytics-unit/nhsx-internship-scheme-innovation-and-analytics-health/$",
+        lambda request: redirect(
+            r"https://nhsengland.github.io/datascience/PhDInterns/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21422

## Testing

Run the local env with `./script/server`, you may need this change:

```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```

Check that these links redirect as per the ticket (note, port will need to be changed if you didn't apply the diff above):

* http://localhost:5001/key-tools-and-info/nhsx-analytics-unit/apply-for-nhsx-analytics-unit-internship/
* http://localhost:5001/key-tools-and-info/nhsx-analytics-unit/nhsx-internship-scheme-innovation-and-analytics-health/