### PR TITLE
additional redirect

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1167,12 +1167,12 @@ urlpatterns = [
     ),
     # https://dxw.zendesk.com/agent/tickets/21370 - additional
     url(
-            r"^information-governance/guidance/virtual-wards/$",
-            lambda request: redirect(
-                r"https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/",
-                permanent=True,
-            ),
+        r"^information-governance/guidance/virtual-wards/$",
+        lambda request: redirect(
+            r"https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/",
+            permanent=True,
         ),
+    ),
 ]
 
 

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1165,6 +1165,14 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21370 - additional
+    url(
+            r"^information-governance/guidance/virtual-wards/$",
+            lambda request: redirect(
+                r"https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/",
+                permanent=True,
+            ),
+        ),
 ]
 
 


### PR DESCRIPTION
This commit redirects the url
https://transform.england.nhs.uk/information-governance/guidance/virtual-wards/ to
https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/

To test
in your local instance
- navigate to http://localhost:5000/information-governance/guidance/virtual-wards/
- confirm that you are redirected to the above nhs england page