### PR TITLE
Remove redirect from virtual-wards

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1121,6 +1121,8 @@ urlpatterns = [
         ),
     ),
     # https://dxw.zendesk.com/agent/tickets/21370
+    # Note the client asked for the redirect from '^information-governance/guidance/virtual-wards/$'
+    # to be removed.
     url(
         r"^key-tools-and-info/a-guide-to-setting-up-technology-enabled-virtual-wards/$",
         lambda request: redirect(
@@ -1132,13 +1134,6 @@ urlpatterns = [
         r"^covid-19-response/technology-nhs/virtual-wards-enabled-by-technology-guidance-on-selecting-and-procuring-a-technology-platform/$",
         lambda request: redirect(
             r"https://www.england.nhs.uk/long-read/virtual-wards-enabled-by-technology-guidance-on-selecting-and-procuring-a-technology-platform/#appendix-1-the-moscow-approach",
-            permanent=True,
-        ),
-    ),
-    url(
-        r"^information-governance/guidance/virtual-wards/$",
-        lambda request: redirect(
-            r"https://www.england.nhs.uk/long-read/virtual-wards-information-governance-guidance/",
             permanent=True,
         ),
     ),


### PR DESCRIPTION
See:
    https://dxw.zendesk.com/agent/tickets/21370

## Testing

Run the local env with `./script/server`, you may need this change:

```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```

and check http://localhost:5001/information-governance/guidance/virtual-wards/ does not redirect (can 404)