### PR TITLE
Redirect NHS internship projects

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1160,6 +1160,14 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21436
+    url(
+        r"^key-tools-and-info/nhsx-analytics-unit/nhsx-internship-projects/$",
+        lambda request: redirect(
+            r"https://nhsengland.github.io/datascience/PhDInterns/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21436

## Testing

Run the local env with `./script/server`, you may need this change:

```diff
❯ git diff
diff --git i/docker-compose.yml w/docker-compose.yml
index 9d4d05a..80da585 100644
--- i/docker-compose.yml
+++ w/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./app/media:/usr/srv/app/media:Z

     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8000:8000"
     links:
       - db
```

and check http://localhost:5001/key-tools-and-info/nhsx-analytics-unit/nhsx-internship-scheme-innovation-and-analytics-health/ redirects to https://nhsengland.github.io/datascience/PhDInterns/
