### PR TITLE
Change referrer policy if page has YouTube embed

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -144,6 +144,7 @@ MIDDLEWARE = [
     "wagtail_2fa.middleware.VerifyUserMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     # ROLLBAR
+    "modules.core.middleware.IframeReferrerMiddleware",
     "rollbar.contrib.django.middleware.RollbarNotifierMiddleware",
     # CACHE
     "wagtailcache.cache.FetchFromCacheMiddleware",  # MUST BE LAST

--- a/app/modules/core/middleware.py
+++ b/app/modules/core/middleware.py
@@ -1,0 +1,7 @@
+class IframeReferrerMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response

--- a/app/modules/core/middleware.py
+++ b/app/modules/core/middleware.py
@@ -1,14 +1,29 @@
 class IframeReferrerMiddleware:
+    YOUTUBE_MARKERS = (
+        "youtube.com",
+        "youtu.be",
+    )
+
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
 
-        if "text/html" in response.get("Content-Type", ""):
-            content = response.content.decode("utf-8")
+        if "text/html" not in response.get("Content-Type", ""):
+            return response
 
-            if "<iframe" in content.lower():
-                response["Referrer-Policy"] = "no-referrer"
+        content = response.content.decode("utf-8").lower()
+        iframes = content.split("<iframe")
+        has_youtube_iframe = False
+
+        for iframe in iframes[1:]:
+            iframe_tag = iframe.split(">", 1)[0] + ">"
+            if any(marker in iframe_tag for marker in self.YOUTUBE_MARKERS):
+                has_youtube_iframe = True
+                break 
+
+        if has_youtube_iframe:
+            response["Referrer-Policy"] = "no-referrer"
 
         return response

--- a/app/modules/core/middleware.py
+++ b/app/modules/core/middleware.py
@@ -4,4 +4,11 @@ class IframeReferrerMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
+
+        if "text/html" in response.get("Content-Type", ""):
+            content = response.content.decode("utf-8")
+
+            if "<iframe" in content.lower():
+                response["Referrer-Policy"] = "no-referrer"
+
         return response


### PR DESCRIPTION
## Description

YouTube embeds don’t support `same-origin` as the `Referrer-Policy`, which caused them to break with the message "Error 153: Video player configuration error."

A temporary workaround was applied via Cloudfront’s policy.

This PR implements a Middleware that overrides the Referrer-Policy for pages containing an iframe with a YouTube URL, using a predefined list of known links.



Related Ticket: https://dxw.zendesk.com/agent/tickets/21504

## How to Test
1. Create a page with an Embed component
2. Add a YouTube link
3. Use `curl` to check the response headers
4. Confirm the `Referrer-Policy` is set to `no-referrer`


## Response example
```
❯ curl -I http://localhost:5000/information-governance/guidance/universal-ig-templates-faqs/

HTTP/1.1 200 OK
Date: Tue, 23 Dec 2025 16:24:20 GMT
Server: WSGIServer/0.2 CPython/3.9.17
Content-Type: text/html; charset=utf-8
Expires: Tue, 23 Dec 2025 16:36:04 GMT
Cache-Control: max-age=900
X-Wagtail-Cache: hit
Referrer-Policy: no-referrer <---------
X-Frame-Options: DENY
Content-Length: 49593
Vary: Accept-Language
Content-Language: en-gb
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
```


