### PR TITLE
Update global Referrer-Policy

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -48,7 +48,6 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = "DENY"
 CSRF_USE_SESSIONS = False
-
 WAGTAIL_2FA_REQUIRED = False
 
 
@@ -467,10 +466,8 @@ if os.environ.get("SECURE_CONTENT_TYPE_NOSNIFF", "true").lower().strip() == "tru
 
 
 # Referrer-policy header settings.
-# https://django-referrer-policy.readthedocs.io/en/1.0/
-
-REFERRER_POLICY = os.environ.get(
-    "SECURE_REFERRER_POLICY", "no-referrer-when-downgrade"
+SECURE_REFERRER_POLICY = os.environ.get(
+    "SECURE_REFERRER_POLICY", "strict-origin-when-cross-origin"
 ).strip()
 
 


### PR DESCRIPTION
## Description

YouTube embeds don’t support `same-origin` as the `Referrer-Policy`, which caused them to break with the message "Error 153: Video player configuration error."

A temporary workaround was applied via Cloudfront’s policy.

This PR update Django settings to change the default Referrer-Policy to `strict-origin-when-cross-origin`.
Related Ticket: https://dxw.zendesk.com/agent/tickets/21504
See:  https://chipcullen.com/django-3-referrer-policy-change/

## How to Test
1. Follow the instructions in the project's `README.md`
3. Use `curl` to check the response headers
4. Confirm the `Referrer-Policy` is set to `strict-origin-when-cross-origin`

If you still don't see the updated Referrer-Policy, make sure to disable [Wagtail caching](https://github.com/patdel0/nhsx-website/blob/885ac9d85ba635bbea1725ee394827e098738c0a/app/config/settings/base.py#L321), by setting it to `False`
## Response example
```
❯ curl -I http://localhost:5000/

HTTP/1.1 200 OK
Date: Wed, 24 Dec 2025 10:34:28 GMT
Server: WSGIServer/0.2 CPython/3.9.17
Content-Type: text/html; charset=utf-8
X-Frame-Options: DENY
Content-Length: 49593
Vary: Accept-Language, Cookie
Content-Language: en-gb
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Referrer-Policy: strict-origin-when-cross-origin <-------
```


