### PR TITLE
Add redirects for digital health partnership award

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1185,6 +1185,28 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21549
+    url(
+        r"^key-tools-and-info/digital-health-partnership-award/$",
+        lambda request: redirect(
+            r"https://webarchive.nationalarchives.gov.uk/ukgwa/20251103060531/https://transform.england.nhs.uk/key-tools-and-info/digital-health-partnership-award/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/digital-health-partnership-award/digital-health-partnership-award-winners-phase-1/$",
+        lambda request: redirect(
+            r"https://webarchive.nationalarchives.gov.uk/ukgwa/20251103060531/https://transform.england.nhs.uk/key-tools-and-info/digital-health-partnership-award/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/digital-health-partnership-award/digital-health-partnership-award-winners-phase-2/$",
+        lambda request: redirect(
+            r"https://webarchive.nationalarchives.gov.uk/ukgwa/20251103060531/https://transform.england.nhs.uk/key-tools-and-info/digital-health-partnership-award/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See:

https://dxw.zendesk.com/agent/tickets/21549

## Testing

1. Spin up the local site with `./scripts/server`
2. Check http://localhost:5000/key-tools-and-info/digital-health-partnership-award/
3. Check http://localhost:5000/key-tools-and-info/digital-health-partnership-award/digital-health-partnership-award-winners-phase-1/
4. Check http://localhost:5000/key-tools-and-info/digital-health-partnership-award/digital-health-partnership-award-winners-phase-2/