### PR TITLE
Add redirects for texting and emailing guidance

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1207,6 +1207,21 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21556
+    url(
+        r'^information-governance/guidance/use-mobile-messaging-software-health-and-care-settings/$',
+        lambda request: redirect(
+            '/information-governance/guidance/texting-emailing-and-messaging-patients-and-service-users/',
+            permanent=True,
+        ),
+    ),
+    url(
+        r'^information-governance/guidance/email-and-text-message-communications/$',
+        lambda request: redirect(
+            '/information-governance/guidance/texting-emailing-and-messaging-patients-and-service-users/',
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
Related ticket: https://dxw.zendesk.com/agent/tickets/21566

## How to Test
1. Run the server `./scripts/server`
2. Confirm the following urls are redirected to `information-governance/guidance/texting-emailing-and-messaging-patients-and-service-users/`:
- http://localhost:5000/information-governance/guidance/use-mobile-messaging-software-health-and-care-settings/
- http://localhost:5000/information-governance/guidance/email-and-text-message-communications/