### PR TITLE
Prod release of redirects

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1222,6 +1222,16 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21564
+    # Note these are both "this page and all associated child pages", hence no
+    # trailing $ in the regexp.
+    url(
+        r"^covid-19-response/technology-nhs/",
+        lambda request: redirect(
+            "https://webarchive.nationalarchives.gov.uk/ukgwa/20250905141205/https:/transform.england.nhs.uk/covid-19-response/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
Note that this includes all child paths, as per the ticket.

See:

https://dxw.zendesk.com/agent/tickets/21564

## Testing

1. Test some URLs based on the ticket, e.g.
    1. https://web.staging.nhsx-website.dalmatian.dxw.net/covid-19-response/technology-nhs/
    2. https://web.staging.nhsx-website.dalmatian.dxw.net/covid-19-response/technology-nhs/flibble