### PR TITLE
Add redirect for digitise paths

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1232,6 +1232,21 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21571
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/$",
+        lambda request: redirect(
+            "https://www.england.nhs.uk/digitaltechnology/digitising-the-frontline/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/our-strategy-to-digitise-connect-and-transform/$",
+        lambda request: redirect(
+            "https://transform.england.nhs.uk/digitise-connect-transform/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21571

## Testing

1. Spin up the local environment
2. Check redirects, as per the tickets, at:
    * http://localhost:5000/digitise-connect-transform/digitising-the-frontline/
    * http://localhost:5000/digitise-connect-transform/our-strategy-to-digitise-connect-and-transform/