### PR TITLE
Add redirects for Digitising the Frontline

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1313,6 +1313,28 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21593
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-midlands/$",
+        lambda request: redirect(
+            "https://webarchive.nationalarchives.gov.uk/ukgwa/20251103060800/https://transform.england.nhs.uk/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-midlands/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-south-west/$",
+        lambda request: redirect(
+            "https://webarchive.nationalarchives.gov.uk/ukgwa/20251103060754/https://transform.england.nhs.uk/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-south-west/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-north-east-and-yorkshire/$",
+        lambda request: redirect(
+            "https://webarchive.nationalarchives.gov.uk/ukgwa/20251103060940/https://transform.england.nhs.uk/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-north-east-and-yorkshire/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See:
    https://dxw.zendesk.com/agent/tickets/21593

## Testing

1. Spin up a local service with `./script/server`
2. Check:
    * http://localhost:5000/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-midlands/
    * http://localhost:5000/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-south-west/
    * http://localhost:5000/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-north-east-and-yorkshire/