### PR TITLE
Prod release

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1374,6 +1374,35 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21726
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-london/$",
+        lambda request: redirect(
+            "https://www.england.nhs.uk/digitaltechnology/digitising-the-frontline/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-north-west/$",
+        lambda request: redirect(
+            "https://www.england.nhs.uk/digitaltechnology/digitising-the-frontline/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-east-of-england/$",
+        lambda request: redirect(
+            "https://www.england.nhs.uk/digitaltechnology/digitising-the-frontline/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-south-east/$",
+        lambda request: redirect(
+            "https://www.england.nhs.uk/digitaltechnology/digitising-the-frontline/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21726

Note that https://dxw.zendesk.com/agent/tickets/21593 also added redirects for some similar URLs. I don't think there's duplication or a redirect loop, but this should be checked.

## Testing

Spin up a local env and check these URLs redirect, as per the ticket:

* https://web.staging.nhsx-website.dalmatian.dxw.net/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-london/
* https://web.staging.nhsx-website.dalmatian.dxw.net/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-north-west/
* https://web.staging.nhsx-website.dalmatian.dxw.net/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-east-of-england/
* https://web.staging.nhsx-website.dalmatian.dxw.net/digitise-connect-transform/digitising-the-frontline/digitising-the-frontline-in-the-south-east/