### PR TITLE
Feature/hide banner per url ticket 21744

### DIFF
--- a/app/config/settings/production.py
+++ b/app/config/settings/production.py
@@ -6,6 +6,10 @@ DEBUG = False
 
 BASE_URL = "https://transform.england.nhs.uk"
 
+BANNER_EXCLUDED_PAGE_URLS = [
+    "information-governance/guidance/child-protection-information-system-cp-is-template-dpia/"
+]
+
 ####################################################################################################
 # Static assets served by Whitenoise
 ####################################################################################################

--- a/app/config/settings/staging.py
+++ b/app/config/settings/staging.py
@@ -12,6 +12,9 @@ BASIC_AUTH_LOGIN = os.environ.get("BASIC_AUTH_LOGIN", "")
 BASIC_AUTH_PASSWORD = os.environ.get("BASIC_AUTH_PASSWORD", "")
 BASIC_AUTH_DISABLE_CONSUMING_AUTHORIZATION_HEADER = True
 
+# Added for testing https://dxw.zendesk.com/agent/tickets/21744
+BANNER_EXCLUDED_PAGE_URLS = ["/about-us/who-we-are/", "/about-us/what-we-do/"]
+
 ####################################################################################################
 # Static assets served by Whitenoise
 ####################################################################################################

--- a/app/modules/core/templatetags/banner_tags.py
+++ b/app/modules/core/templatetags/banner_tags.py
@@ -1,0 +1,10 @@
+# core/templatetags/banner_tags.py
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=False)
+def banner_excluded_urls():
+    return getattr(settings, "BANNER_EXCLUDED_PAGE_URLS", [])

--- a/app/templates/_partials/site_wide_banner.html
+++ b/app/templates/_partials/site_wide_banner.html
@@ -1,11 +1,12 @@
-{% load wagtailsettings_tags wagtailcore_tags %}
+{% load wagtailsettings_tags wagtailcore_tags banner_tags %}
 {% get_settings use_default_site=True %}
+{% banner_excluded_urls as excluded_urls %}
 
-{% if settings.core.SiteWideBannerSettings.banner_enabled and settings.core.SiteWideBannerSettings.site_wide_banner_body %}
+{% if settings.core.SiteWideBannerSettings.banner_enabled and settings.core.SiteWideBannerSettings.site_wide_banner_body and page.url not in excluded_urls %}
     <div class="alert-banner-container {{ settings.core.SiteWideBannerSettings.site_wide_banner_theme }}">
         <div class="nhsuk-width-container">
             <article>
-                {{ settings.core.SiteWideBannerSettings.site_wide_banner_body|richtext  }}
+                {{ settings.core.SiteWideBannerSettings.site_wide_banner_body|richtext }}
             </article>
         </div>
     </div>


### PR DESCRIPTION
The site-wide banner appears on every page except the front page.

TE now has one page that should not show the banner. This commit adds a template tag which reads a list of URLs from settings to exclude particular pages from displaying the banenr.

See:
https://dxw.zendesk.com/agent/tickets/21744

## Testing 


1. Run a local environment with `./script/server`
1. Visit http://localhost:5000/admin and log in with `admin@example.com` / `admin`
1. Visit http://localhost:5000/admin/settings/core/sitewidebannersettings/2/ and enable the site-wide banner with some text
1. Visit http://localhost:5000/admin/pages/ and create at least two pages, in addition to the home page. Note that any other pages must be child pages of the home page.
1. Visit your non-home pages on the front end and check that the site-wide banner appears
1. Add the path of the new page to `app/config/settings/development.py` like this:
    ```python
    BANNER_EXCLUDED_PAGE_URLS = ["/news/"]
    ```
1. Wait for the page to rebuild and refresh your browser. Check the site-wide banner does _not_ appear on your page.
1. Check that the banner _does_ appear on any other pages you have (note that it will not appear on the homepage).

## Screenshots

### Page without banner


<img width="699" height="187" alt="page-without-banner" src="https://github.com/user-attachments/assets/c3de8e67-1677-4a46-b532-c0952c34e61b" />

### Page with banner

<img width="701" height="262" alt="page-with-banner" src="https://github.com/user-attachments/assets/97fc70f7-abad-46e7-b45b-c63b22b1e4d0" />
