### PR TITLE
Redirect digital-clinical-strategy

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1403,6 +1403,14 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21779
+    url(
+        r"^key-tools-and-info/digital-clinical-safety-strategy/$",
+        lambda request: redirect(
+            "https://www.england.nhs.uk/long-read/digital-clinical-safety-strategy/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21779

## Testing

1. Run a local server with `./script/serve`
2. Check http://localhost:5000/key-tools-and-info/digital-clinical-safety-strategy/ redirects as per the ticket