### PR TITLE
Exclude specific page from having 'This guidance has been reviewed..' banner

### DIFF
--- a/app/templates/ig_guidance/internal_guidance.html
+++ b/app/templates/ig_guidance/internal_guidance.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags guidance_tags %}
+{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags guidance_tags banner_tags %}
+{% banner_excluded_urls as excluded_urls %}
 
 {% block body_class %}template-guidance{% endblock %}
 
@@ -13,7 +14,9 @@
 {% block content %}
 <div class="template-guidance__warning">
   <div class="nhsuk-width-container">
-    <p class="template-guidance__warning__body"><strong>This guidance has been reviewed by the Health and Care Information Governance Working Group, including the Information Commissioner's Office (ICO) and National Data Guardian (NDG).</strong></p>
+    {% if page.url not in excluded_urls %}
+      <p class="template-guidance__warning__body"><strong>This guidance has been reviewed by the Health and Care Information Governance Working Group, including the Information Commissioner's Office (ICO) and National Data Guardian (NDG).</strong></p>
+    {% endif %}
     <p class="template-guidance__warning__body">Have we done a good job? <a href="https://nhsplatform.corestream.co.uk/public/form/IGPolicyQuery">Let us know</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
## Description

Need to exclude banner on https://transform.england.nhs.uk/information-governance/guidance/child-protection-information-system-cp-is-template-dpia/ 
Uses BANNER_EXCLUDED_PAGE_URLS from app/config/settings/production.py which specifies the required page

Ticket: https://dxw.zendesk.com/agent/tickets/21788

## Test

I'm not sure how to test locally.
On staging, it should not break any pages, specifically Guidance template pages such as https://web.staging.nhsx-website.dalmatian.dxw.net/information-governance/guidance/internal-guidance/
Then hopefully will do the job on prod