### PR TITLE
Revert "Exclude specific page from having 'This guidance has been reviewed..' banner

### DIFF
--- a/app/templates/ig_guidance/internal_guidance.html
+++ b/app/templates/ig_guidance/internal_guidance.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags guidance_tags banner_tags %}
-{% banner_excluded_urls as excluded_urls %}
+{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags guidance_tags %}
 
 {% block body_class %}template-guidance{% endblock %}
 
@@ -14,9 +13,7 @@
 {% block content %}
 <div class="template-guidance__warning">
   <div class="nhsuk-width-container">
-    {% if page.url not in excluded_urls %}
-      <p class="template-guidance__warning__body"><strong>This guidance has been reviewed by the Health and Care Information Governance Working Group, including the Information Commissioner's Office (ICO) and National Data Guardian (NDG).</strong></p>
-    {% endif %}
+    <p class="template-guidance__warning__body"><strong>This guidance has been reviewed by the Health and Care Information Governance Working Group, including the Information Commissioner's Office (ICO) and National Data Guardian (NDG).</strong></p>
     <p class="template-guidance__warning__body">Have we done a good job? <a href="https://nhsplatform.corestream.co.uk/public/form/IGPolicyQuery">Let us know</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
### Description

This reverts commit 6208fc8fc6a2ef911211e7fc240dff36d72f48a0.

The change removed the banner from all pages using the template rather than just the one page.