### PR TITLE
Add redirects to DTAC page

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1426,6 +1426,35 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21824
+    url(
+        r"^key-tools-and-info/digital-technology-assessment-criteria-dtac/value-proposition-non-assessed-section/$",
+        lambda request: redirect(
+            "https://transform.england.nhs.uk/key-tools-and-info/digital-technology-assessment-criteria-dtac/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/digital-technology-assessment-criteria-dtac/assessment-criteria-assessed-section/$",
+        lambda request: redirect(
+            "https://transform.england.nhs.uk/key-tools-and-info/digital-technology-assessment-criteria-dtac/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/digital-technology-assessment-criteria-dtac/key-principles-success/$",
+        lambda request: redirect(
+            "https://transform.england.nhs.uk/key-tools-and-info/digital-technology-assessment-criteria-dtac/",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/digital-technology-assessment-criteria-dtac/how-to-use-the-dtac/$",
+        lambda request: redirect(
+            "https://transform.england.nhs.uk/key-tools-and-info/digital-technology-assessment-criteria-dtac/",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21824


## Testing

1. Run a local server with ./script/serve
1. Check these URLs redirect as per the ticket:
    * http://localhost:5000/key-tools-and-info/digital-technology-assessment-criteria-dtac/value-proposition-non-assessed-section/
    * http://localhost:5000/key-tools-and-info/digital-technology-assessment-criteria-dtac/assessment-criteria-assessed-section/
    * http://localhost:5000/key-tools-and-info/digital-technology-assessment-criteria-dtac/key-principles-success/
    * http://localhost:5000/key-tools-and-info/digital-technology-assessment-criteria-dtac/how-to-use-the-dtac/
