### PR TITLE
Fix/ci for new ubuntu

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,9 +4,8 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1
       - name: Run tests in Docker
         run: script/cibuild
-

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -6,6 +6,6 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Run tests in Docker
         run: script/cibuild

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -88,7 +88,7 @@ ENV POETRY_VIRTUALENVS_CREATE=0 \
 
 # Linking of pip/python and deleting of directories from original pip install: not known if needed.
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+RUN curl https://bootstrap.pypa.io/pip/3.9/get-pip.py -o get-pip.py && \
     python3 get-pip.py --force-reinstall && \
     rm /usr/bin/pip && \
     ln -s /usr/bin/pip3 /usr/bin/pip && \

--- a/docker/web/Dockerfile-prod
+++ b/docker/web/Dockerfile-prod
@@ -84,7 +84,7 @@ ENV POETRY_VIRTUALENVS_CREATE=0 \
 
 # Linking of pip/python and deleting of directories from original pip install: not known if needed.
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+RUN curl https://bootstrap.pypa.io/pip/3.9/get-pip.py -o get-pip.py && \
     python3 get-pip.py --force-reinstall && \
     rm /usr/bin/pip && \
     ln -s /usr/bin/pip3 /usr/bin/pip && \


### PR DESCRIPTION
It's not just Ubuntu that has changed and broken the build, but this PR:

* Pins Ubuntu in CI rather than using `latest`
* Updates `actions/checkout` to latest
* Updates pip to a version compatible with the installed Python version