### PR TITLE
More redirects for information governance

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1863,6 +1863,21 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21903
+    url(
+        r"^information-governance/strategic-information-governance-networks-signs/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/data-and-information/information-governance/national-sign",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^information-governance/caf-aligned-dspt-evolution-of-our-assurance-model/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/data-and-information/information-governance/evolution-of-our-assurance-model",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See ticket: https://dxw.zendesk.com/agent/tickets/21903

## Testing

Run `./script/server` to view the local environment, check these URLs against the ticket:

* http://localhost:5000/information-governance/strategic-information-governance-networks-signs/
* http://localhost:5000/information-governance/caf-aligned-dspt-evolution-of-our-assurance-model/