### PR TITLE
Add what-good-looks-like redirects

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1878,6 +1878,28 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21913
+    url(
+        r"^digitise-connect-transform/what-good-looks-like/$",
+        lambda request: redirect(
+            r"https://future.nhs.uk/WhatGoodLooksLikeKnowledge/grouphome",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/what-good-looks-like/what-good-looks-like-publication/$",
+        lambda request: redirect(
+            r"https://future.nhs.uk/WhatGoodLooksLikeKnowledge/grouphome",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^digitise-connect-transform/what-good-looks-like/guidance-for-nursing-on-what-good-looks-like/$",
+        lambda request: redirect(
+            r"https://future.nhs.uk/WhatGoodLooksLikeKnowledge/grouphome",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21913

## Testing

Run `./script/setup && ./script/server` and test:

* http://localhost:5000/digitise-connect-transform/what-good-looks-like/
* http://localhost:5000/digitise-connect-transform/what-good-looks-like/what-good-looks-like-publication/
* http://localhost:5000/digitise-connect-transform/what-good-looks-like/guidance-for-nursing-on-what-good-looks-like/

all redirect to: https://future.nhs.uk/WhatGoodLooksLikeKnowledge/grouphome