### PR TITLE
Redirect for DTAC

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -1922,6 +1922,14 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21920
+    url(
+        r"^key-tools-and-info/digital-technology-assessment-criteria-dtac/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-technology-assessment-criteria-dtac",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See: https://dxw.zendesk.com/agent/tickets/21920

## Testing

Start a local server with `./script/setup && ./script/server`

Visit:

http://localhost:5000/key-tools-and-info/digital-technology-assessment-criteria-dtac/ 

and check that it redirects as per the ticket.