### PR TITLE
More redirects for ticket 21939

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -2324,6 +2324,70 @@ urlpatterns = [
             permanent=True,
         ),
     ),
+    # https://dxw.zendesk.com/agent/tickets/21939
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/introduction/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/introduction",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/understanding-rpa/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/understanding-rpa",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/getting-started-with-rpa/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/getting-started-with-rpa",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/delivering-rpa/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/delivering-rpa",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/sustaining-rpa/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/sustaining-rpa",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/technology-for-rpa/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/technology-for-rpa",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/checklist/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/checklist",
+            permanent=True,
+        ),
+    ),
+    url(
+        r"^key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/additional-information/$",
+        lambda request: redirect(
+            r"https://digital.nhs.uk/services/digital-services-for-integrated-care/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/additional-information",
+            permanent=True,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
See:
https://dxw.zendesk.com/agent/tickets/21939

## Testing

Spin up a local site with `./script/setup && ./script/server` then check that the following URLs redirect as per the ticket:

- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/introduction/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/understanding-rpa/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/getting-started-with-rpa/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/delivering-rpa/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/sustaining-rpa/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/technology-for-rpa/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/checklist/
- http://localhost:5000/key-tools-and-info/guidance-for-designing-delivering-and-sustaining-rpa-within-the-nhs/additional-information/
